### PR TITLE
Week 62: DataSource Abstraction (S31-S35)

### DIFF
--- a/data/quality/__init__.py
+++ b/data/quality/__init__.py
@@ -1,0 +1,3 @@
+from data.quality.gate import DataIssue, DataQualityGate, validate
+
+__all__ = ["DataIssue", "DataQualityGate", "validate"]

--- a/data/quality/gate.py
+++ b/data/quality/gate.py
@@ -1,0 +1,225 @@
+"""
+DataQualityGate — validates OHLCV DataFrames before they enter the environment (Week 62, S33).
+
+Usage::
+
+    from data.quality.gate import validate, DataQualityGate
+
+    issues = validate(df)                   # module-level shortcut
+    gate = DataQualityGate(max_gap_bars=5)
+    gate.check(df)                          # raises DataQualityError on first error
+
+Issue types
+-----------
+- nan_inf         : NaN or ±inf found in any numeric column
+- negative_price  : $open / $high / $low / $close ≤ 0
+- zero_volume     : $volume == 0 for a bar
+- time_gap        : gap between consecutive bars exceeds ``max_gap_bars`` (requires
+                    a DatetimeIndex or a column named ``timestamp`` / ``time`` / ``date``)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Issue dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DataIssue:
+    """Describes a single data quality problem."""
+
+    kind: str          # 'nan_inf' | 'negative_price' | 'zero_volume' | 'time_gap'
+    row: Optional[int] # 0-based row index where the issue was found (None if global)
+    column: Optional[str]  # column name, if applicable
+    detail: str        # human-readable description
+
+    def __str__(self) -> str:
+        loc = f"row={self.row}" if self.row is not None else "global"
+        col = f", col={self.column}" if self.column else ""
+        return f"[{self.kind}] {loc}{col}: {self.detail}"
+
+
+class DataQualityError(ValueError):
+    """Raised by DataQualityGate.check() when issues are found."""
+
+    def __init__(self, issues: List[DataIssue]) -> None:
+        self.issues = issues
+        msg = f"{len(issues)} data quality issue(s):\n" + "\n".join(
+            f"  {i}" for i in issues
+        )
+        super().__init__(msg)
+
+
+# ---------------------------------------------------------------------------
+# Gate implementation
+# ---------------------------------------------------------------------------
+
+_PRICE_COLS = ["$open", "$high", "$low", "$close"]
+_ALL_NUMERIC = ["$open", "$high", "$low", "$close", "$volume"]
+_TIME_COL_NAMES = {"timestamp", "time", "date", "datetime"}
+
+
+class DataQualityGate:
+    """
+    Validates an OHLCV DataFrame and returns a list of :class:`DataIssue` objects.
+
+    Args:
+        max_gap_bars: Maximum allowed consecutive missing bars when a datetime
+            index / column is present.  ``None`` disables the gap check.
+        raise_on_issue: If True, :meth:`check` raises :class:`DataQualityError`
+            immediately instead of collecting all issues.
+    """
+
+    def __init__(
+        self,
+        max_gap_bars: Optional[int] = None,
+        raise_on_issue: bool = False,
+    ) -> None:
+        self.max_gap_bars = max_gap_bars
+        self.raise_on_issue = raise_on_issue
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def validate(self, df: pd.DataFrame) -> List[DataIssue]:
+        """Return all issues found.  Never raises."""
+        issues: List[DataIssue] = []
+        issues.extend(self._check_nan_inf(df))
+        issues.extend(self._check_negative_price(df))
+        issues.extend(self._check_zero_volume(df))
+        if self.max_gap_bars is not None:
+            issues.extend(self._check_time_gap(df))
+        return issues
+
+    def check(self, df: pd.DataFrame) -> None:
+        """Validate and raise :class:`DataQualityError` if any issues found."""
+        issues = self.validate(df)
+        if issues:
+            raise DataQualityError(issues)
+
+    # ------------------------------------------------------------------
+    # Individual checks
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _check_nan_inf(df: pd.DataFrame) -> List[DataIssue]:
+        issues: List[DataIssue] = []
+        for col in _ALL_NUMERIC:
+            if col not in df.columns:
+                continue
+            series = df[col]
+            bad_mask = series.isna() | series.isin([math.inf, -math.inf])
+            for row in df.index[bad_mask]:
+                val = series.loc[row]
+                issues.append(
+                    DataIssue(
+                        kind="nan_inf",
+                        row=int(row),
+                        column=col,
+                        detail=f"value={val!r}",
+                    )
+                )
+        return issues
+
+    @staticmethod
+    def _check_negative_price(df: pd.DataFrame) -> List[DataIssue]:
+        issues: List[DataIssue] = []
+        for col in _PRICE_COLS:
+            if col not in df.columns:
+                continue
+            bad_mask = df[col] <= 0
+            for row in df.index[bad_mask]:
+                val = df[col].loc[row]
+                issues.append(
+                    DataIssue(
+                        kind="negative_price",
+                        row=int(row),
+                        column=col,
+                        detail=f"value={val}",
+                    )
+                )
+        return issues
+
+    @staticmethod
+    def _check_zero_volume(df: pd.DataFrame) -> List[DataIssue]:
+        issues: List[DataIssue] = []
+        if "$volume" not in df.columns:
+            return issues
+        bad_mask = df["$volume"] == 0
+        for row in df.index[bad_mask]:
+            issues.append(
+                DataIssue(
+                    kind="zero_volume",
+                    row=int(row),
+                    column="$volume",
+                    detail="volume=0",
+                )
+            )
+        return issues
+
+    def _check_time_gap(self, df: pd.DataFrame) -> List[DataIssue]:
+        """Detect irregular time gaps when a datetime axis is available."""
+        issues: List[DataIssue] = []
+
+        # Try to find a datetime series to diff
+        dt_series: Optional[pd.Series] = None
+        if isinstance(df.index, pd.DatetimeIndex):
+            dt_series = df.index.to_series().reset_index(drop=True)
+        else:
+            for col in df.columns:
+                if col.lower() in _TIME_COL_NAMES:
+                    try:
+                        dt_series = pd.to_datetime(df[col]).reset_index(drop=True)
+                        break
+                    except Exception:
+                        pass
+
+        if dt_series is None or len(dt_series) < 2:
+            return issues
+
+        diffs = dt_series.diff().dropna()
+        if len(diffs) == 0:
+            return issues
+
+        # Use the median diff as the expected bar period
+        median_diff = diffs.median()
+        if median_diff.total_seconds() == 0:
+            return issues
+
+        threshold = median_diff * (self.max_gap_bars + 1)
+        for idx, diff in diffs.items():
+            if diff > threshold:
+                row_int = int(idx)
+                issues.append(
+                    DataIssue(
+                        kind="time_gap",
+                        row=row_int,
+                        column=None,
+                        detail=(
+                            f"gap={diff} exceeds threshold={threshold} "
+                            f"(median_bar={median_diff}, max_gap_bars={self.max_gap_bars})"
+                        ),
+                    )
+                )
+        return issues
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience
+# ---------------------------------------------------------------------------
+
+_DEFAULT_GATE = DataQualityGate()
+
+
+def validate(df: pd.DataFrame) -> List[DataIssue]:
+    """Module-level shortcut: return all data quality issues in *df*."""
+    return _DEFAULT_GATE.validate(df)

--- a/data/sources/__init__.py
+++ b/data/sources/__init__.py
@@ -1,3 +1,5 @@
 from data.sources.base import DataSource, StaticDataSource
+from data.sources.csv_source import CSVDataSource
+from data.sources.mock_live_source import MockLiveDataSource
 
-__all__ = ["DataSource", "StaticDataSource"]
+__all__ = ["DataSource", "StaticDataSource", "CSVDataSource", "MockLiveDataSource"]

--- a/data/sources/csv_source.py
+++ b/data/sources/csv_source.py
@@ -1,0 +1,84 @@
+"""
+CSVDataSource — lazy-loading file-backed DataSource (Week 62, S32).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from data.sources.base import DataSource
+
+
+class CSVDataSource(DataSource):
+    """
+    Loads OHLCV data from a CSV file on first access (lazy).
+
+    Column auto-renaming:
+    - plain names (open/high/low/close/volume) → $open/$high/$low/$close/$volume
+    - dollar-prefixed names are kept as-is
+
+    Args:
+        path: Path to the CSV file.
+        **read_csv_kwargs: Additional kwargs forwarded to ``pd.read_csv``
+            (e.g. ``parse_dates=["timestamp"]``).
+    """
+
+    RENAME_MAP = {
+        "open": "$open",
+        "high": "$high",
+        "low": "$low",
+        "close": "$close",
+        "volume": "$volume",
+    }
+    REQUIRED_COLS = ["$open", "$high", "$low", "$close", "$volume"]
+
+    def __init__(self, path: str, **read_csv_kwargs) -> None:
+        self._path = path
+        self._read_csv_kwargs = read_csv_kwargs
+        self._df: pd.DataFrame | None = None  # loaded on first access
+
+    # ------------------------------------------------------------------
+    # Lazy loading
+    # ------------------------------------------------------------------
+
+    def _load(self) -> None:
+        if self._df is not None:
+            return
+        df = pd.read_csv(self._path, **self._read_csv_kwargs)
+        # Normalise column names
+        df = df.rename(columns={k: v for k, v in self.RENAME_MAP.items() if k in df.columns})
+        missing = [c for c in self.REQUIRED_COLS if c not in df.columns]
+        if missing:
+            raise ValueError(
+                f"CSVDataSource: missing required columns {missing} in {self._path}"
+            )
+        self._df = df.reset_index(drop=True)
+
+    # ------------------------------------------------------------------
+    # DataSource interface
+    # ------------------------------------------------------------------
+
+    def get_window(self, start: int, end: int) -> pd.DataFrame:
+        self._load()
+        return self._df.iloc[start:end]  # type: ignore[index]
+
+    def latest(self) -> pd.Series:
+        self._load()
+        return self._df.iloc[-1]  # type: ignore[index]
+
+    def __len__(self) -> int:
+        self._load()
+        return len(self._df)  # type: ignore[arg-type]
+
+    def is_live(self) -> bool:
+        return False
+
+    # ------------------------------------------------------------------
+    # Optional direct access (read-only contract)
+    # ------------------------------------------------------------------
+
+    @property
+    def df(self) -> pd.DataFrame:
+        """Expose the underlying DataFrame (loaded on first access)."""
+        self._load()
+        return self._df  # type: ignore[return-value]

--- a/data/sources/mock_live_source.py
+++ b/data/sources/mock_live_source.py
@@ -1,0 +1,84 @@
+"""
+MockLiveDataSource — simulates a live streaming feed for testing (Week 62, S32).
+
+The "clock" advances one bar at a time via ``tick()``.  Only bars up to the
+current tick are visible, mimicking a real-time data source where future data
+is unknown.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from data.sources.base import DataSource
+
+
+class MockLiveDataSource(DataSource):
+    """
+    Wraps a static DataFrame but exposes it as if data arrives bar by bar.
+
+    Behaviour:
+    - At initialisation the clock is at tick 0 (one bar visible: bar 0).
+    - ``tick()`` advances the clock by one bar.
+    - ``get_window(start, end)`` returns rows in [start, end) **up to
+      the current tick** — future bars raise IndexError.
+    - ``latest()`` returns the bar at the current tick.
+    - ``__len__()`` returns the *total* dataset length (how many bars exist
+      in the underlying DataFrame), not the number of visible bars.
+      Use ``current_tick`` to know how many bars have been seen.
+    - ``is_live()`` returns True.
+
+    Args:
+        df: Full OHLCV DataFrame (all bars, pre-loaded).
+        initial_tick: Starting tick index (default 0).
+    """
+
+    def __init__(self, df: pd.DataFrame, initial_tick: int = 0) -> None:
+        if df is None or len(df) == 0:
+            raise ValueError("MockLiveDataSource requires a non-empty DataFrame")
+        self._df = df.reset_index(drop=True)
+        if not (0 <= initial_tick < len(self._df)):
+            raise ValueError(
+                f"initial_tick={initial_tick} out of range [0, {len(self._df) - 1}]"
+            )
+        self._tick: int = initial_tick
+
+    # ------------------------------------------------------------------
+    # Clock control
+    # ------------------------------------------------------------------
+
+    @property
+    def current_tick(self) -> int:
+        """Index of the latest visible bar (0-based)."""
+        return self._tick
+
+    def tick(self, n: int = 1) -> None:
+        """Advance the clock by *n* bars.  Stops at the last bar."""
+        self._tick = min(self._tick + n, len(self._df) - 1)
+
+    def reset(self, tick: int = 0) -> None:
+        """Reset the clock to *tick*."""
+        if not (0 <= tick < len(self._df)):
+            raise ValueError(f"tick={tick} out of range")
+        self._tick = tick
+
+    # ------------------------------------------------------------------
+    # DataSource interface
+    # ------------------------------------------------------------------
+
+    def get_window(self, start: int, end: int) -> pd.DataFrame:
+        """Return rows [start, end).  Clamps *end* to current_tick + 1."""
+        visible_end = min(end, self._tick + 1)
+        if start > visible_end:
+            return self._df.iloc[0:0]  # empty frame with correct columns
+        return self._df.iloc[start:visible_end]
+
+    def latest(self) -> pd.Series:
+        return self._df.iloc[self._tick]
+
+    def __len__(self) -> int:
+        """Total bars in the underlying dataset (not just visible ones)."""
+        return len(self._df)
+
+    def is_live(self) -> bool:
+        return True

--- a/docs/phase6/week62.md
+++ b/docs/phase6/week62.md
@@ -1,0 +1,89 @@
+# Week 62 Retrospective — DataSource Abstraction (S31-S35)
+
+**날짜**: 2026-04-10  
+**브랜치**: claude/determined-keller  
+**PR**: Week 62 DataSource Abstraction (S31-S35)
+
+---
+
+## What
+
+DataSource 인터페이스를 완전히 확장하고, `SingleAssetRLTradingEnv`가 내부에서 `df.iloc[step]`을 직접 쓰지 않도록 리팩터링했다.
+
+### 변경 파일 요약
+
+| 파일 | 역할 |
+|------|------|
+| `data/sources/base.py` | DataSource ABC + StaticDataSource (Week 61에서 존재, 확인) |
+| `data/sources/csv_source.py` | CSVDataSource — lazy load, 컬럼명 자동 정규화 |
+| `data/sources/mock_live_source.py` | MockLiveDataSource — tick 기반 bar-by-bar 시뮬레이션 |
+| `data/quality/gate.py` | DataQualityGate + DataIssue — NaN/inf, 음수 가격, zero volume, 시간 gap 체크 |
+| `data/sources/__init__.py` | 신규 exports 추가 |
+| `data/quality/__init__.py` | 패키지 초기화 |
+| `envs/single_asset_rl_env.py` | `_ds_len()`, `_row_at()`, `_window_at()` 헬퍼 추가, 모든 내부 `self.data.iloc[...]` / `len(self.data)` 제거 |
+| `tests/data/test_data_sources.py` | 44개 신규 테스트 |
+
+---
+
+## Why
+
+- 기존 Env는 `self.data.iloc[step]`으로 DataFrame을 직접 접근했다. `StaticDataSource`가 아닌 DataSource(`MockLiveDataSource` 등)를 주입하면 `self.data`가 `None`이어서 즉시 crash.
+- Live 모드 테스트, CSV 로딩, 미래 데이터 차단 등을 위해 DataSource 인터페이스를 완전히 활용할 수 있어야 한다.
+- DataSource를 거치기 전 데이터 품질을 검증하는 gate가 없으면 NaN이 환경에 흘러들어 보상이 오염된다.
+
+---
+
+## Implementation Notes
+
+### S34 접근 방식
+
+헬퍼 세 개를 추가해 모든 내부 접근을 간접화:
+
+```python
+def _ds_len(self) -> int: ...
+def _row_at(self, step: int) -> pd.Series: ...
+def _window_at(self, start: int, end: int) -> pd.DataFrame: ...
+```
+
+- `self.data` 속성은 **그대로 유지** (외부 테스트 및 기존 코드가 직접 읽음). backward-compat 유지.
+- MockLiveDataSource를 주입하면 `self.data = None`이지만, `_ds_len()` / `_row_at()` 는 `self.data_source`를 경유하므로 문제없음.
+
+### MockLiveDataSource tick 모델
+
+- `tick()` 호출 전까지 미래 bar는 보이지 않음 (`get_window`가 visible_end로 clamp).
+- `__len__()` = 전체 데이터셋 길이. 환경이 에피소드 종료 시점을 판단하는 데 사용.
+- `current_tick` property로 현재 몇 번째 bar까지 보였는지 추적.
+
+### DataQualityGate time gap 체크
+
+- DataFrame 인덱스가 DatetimeIndex이거나 `timestamp` / `time` / `date` 컬럼이 있으면 활성화.
+- median bar duration 기준으로 `max_gap_bars + 1` 배 초과 시 issue 발생.
+- 컬럼/인덱스 없으면 gap 체크 skipped (조용히 무시, 에러 아님).
+
+---
+
+## Gotchas
+
+1. **sentiment_data 길이 체크**: 기존엔 `len(self.data) != len(sentiment_data)` 비교했는데, `self.data`가 None인 경우를 방어해야 해서 `_ds_len()` 사용으로 변경.
+2. **`_window_at(0, end_idx)` 에서 end_idx가 0인 경우**: `get_window(0, 0)`은 빈 DataFrame을 반환하도록 MockLiveDataSource가 처리함.
+3. **CSVDataSource 열 rename 순서**: `$open`이 이미 있는데 `open`도 있으면 충돌할 수 있음. rename_map은 plain name만 타겟팅해 실제론 문제없음.
+
+---
+
+## Test Results
+
+```
+새 테스트:  44 passed (tests/data/test_data_sources.py)
+전체 회귀:  1558 passed, 0 failed, 19 skipped
+```
+
+기존 1386 baseline 그대로 유지.
+
+---
+
+## Phase 6 완료 조건 진행 상황
+
+- [x] UnifiedRiskManager (Week 60)
+- [x] DI Refactor (Week 61)
+- [x] DataSource Abstraction (Week 62) ← 이번 주
+- [ ] Config Consolidation (Week 63)

--- a/envs/single_asset_rl_env.py
+++ b/envs/single_asset_rl_env.py
@@ -115,6 +115,9 @@ class SingleAssetRLTradingEnv(gym.Env):
 
         # Initialize data
         # S27 (Week 61): data_source takes priority; legacy `data=` is wrapped.
+        # S34 (Week 62): env accesses data exclusively via self.data_source interface.
+        # self.data is kept as a backward-compat attribute for callers that read it
+        # directly, but all internal logic routes through self.data_source.
         if data_source is not None:
             self.data_source: Optional[DataSource] = data_source
             self.data = data_source.df if isinstance(data_source, StaticDataSource) else None
@@ -202,10 +205,11 @@ class SingleAssetRLTradingEnv(gym.Env):
         self.sentiment_data = None
         self._n_sentiment = 0
         if sentiment_data is not None:
-            if self.data is not None and len(sentiment_data) != len(self.data):
+            _ds_len = self._ds_len()
+            if _ds_len > 0 and len(sentiment_data) != _ds_len:
                 raise ValueError(
                     f"sentiment_data length ({len(sentiment_data)}) must match "
-                    f"data length ({len(self.data)})"
+                    f"data length ({_ds_len})"
                 )
             self.sentiment_data = sentiment_data.reset_index(drop=True)
             self._n_sentiment = 4
@@ -256,12 +260,40 @@ class SingleAssetRLTradingEnv(gym.Env):
         )
         
         # STEP 1-A: Check if data is long enough
+        _len = self._ds_len()
+        if _len > 0 and _len < self.window_size + 1:
+            raise ValueError(
+                f"Data too short ({_len}) for window_size={self.window_size}. "
+                f"Need at least window_size+1 rows."
+            )
+
+    # ------------------------------------------------------------------
+    # DataSource access helpers (S34, Week 62)
+    # ------------------------------------------------------------------
+
+    def _ds_len(self) -> int:
+        """Return total number of bars via DataSource interface."""
+        if self.data_source is not None:
+            return len(self.data_source)
         if self.data is not None:
-            if len(self.data) < self.window_size + 1:
-                raise ValueError(
-                    f"Data too short ({len(self.data)}) for window_size={self.window_size}. "
-                    f"Need at least window_size+1 rows."
-                )
+            return len(self.data)
+        return 0
+
+    def _row_at(self, step: int) -> "pd.Series":
+        """Return a single bar (row) by index via DataSource interface."""
+        if self.data_source is not None:
+            window = self.data_source.get_window(step, step + 1)
+            if len(window) == 0:
+                raise IndexError(f"DataSource has no row at step={step}")
+            return window.iloc[0]
+        # Fallback for legacy self.data path (should not be reached after S34)
+        return self.data.iloc[step]
+
+    def _window_at(self, start: int, end: int) -> "pd.DataFrame":
+        """Return rows [start, end) via DataSource interface."""
+        if self.data_source is not None:
+            return self.data_source.get_window(start, end)
+        return self.data.iloc[start:end]
 
     def set_regime_probs(self, regime_probs) -> None:
         """Week 30: 외부에서 HMM regime 확률을 주입한다. step()에서 position sizing에 반영."""
@@ -273,7 +305,7 @@ class SingleAssetRLTradingEnv(gym.Env):
         """Reset environment to initial state"""
         super().reset(seed=seed)
 
-        if self.data is None:
+        if self.data_source is None and self.data is None:
             raise ValueError("No data provided to environment")
 
         # Reset state variables
@@ -311,9 +343,10 @@ class SingleAssetRLTradingEnv(gym.Env):
         # Store the portfolio value before taking action
         self.previous_portfolio_value = self._calculate_portfolio_value(self.current_step)
 
-        # Get current price data
-        current_price = self.data.iloc[self.current_step]["$close"]
-        current_volume = self.data.iloc[self.current_step]["$volume"]
+        # Get current price data via DataSource interface (S34, Week 62)
+        _current_row = self._row_at(self.current_step)
+        current_price = _current_row["$close"]
+        current_volume = _current_row["$volume"]
         
         # DEBUG: Check for extreme price values
         if current_price <= 0 or np.isnan(current_price) or np.isinf(current_price):
@@ -547,11 +580,11 @@ class SingleAssetRLTradingEnv(gym.Env):
 
         # Move to next step
         self.current_step += 1
-        self.done = self.done or (self.current_step >= len(self.data))
-        
+        self.done = self.done or (self.current_step >= self._ds_len())
+
         # Calculate new portfolio value after action and step
         # --- START: Added Portfolio Calc Logging ---
-        portfolio_calc_price = self.data.iloc[self.current_step - 1]["$close"]
+        portfolio_calc_price = self._row_at(self.current_step - 1)["$close"]
         # Handle potential invalid price during calculation
         if portfolio_calc_price <= 0 or np.isnan(portfolio_calc_price) or np.isinf(portfolio_calc_price):
              self.logger.warning(f"❌ Invalid price used in portfolio calculation at step {self.current_step}: {portfolio_calc_price}. Using 1.0 as fallback.")
@@ -703,7 +736,7 @@ class SingleAssetRLTradingEnv(gym.Env):
         info.update(_risk_limit_info)
 
         # If we decided self.done = True above, we can forcibly end now
-        if self.done and self.current_step < len(self.data):  # Only early termination, not normal end
+        if self.done and self.current_step < self._ds_len():  # Only early termination, not normal end
             # Smaller penalty for capital <= 1.0
             if self.current_capital <= 1.0:
                 reward = -1.0  # Reduced from -10.0 to -1.0 for stability
@@ -1030,24 +1063,25 @@ class SingleAssetRLTradingEnv(gym.Env):
         start_idx = self.current_step - self.window_size
         end_idx = self.current_step
         
-        # Handle negative start index with padding
+        # Handle negative start index with padding (via DataSource interface, S34)
         if start_idx < 0:
             pad_size = abs(start_idx)
-            # Get available data up to current step
-            partial_data = self.data.iloc[:end_idx]
-            
+            # Get available data up to current step via DataSource
+            partial_data = self._window_at(0, end_idx)
+
             # If no data available yet, pad with first row
             if len(partial_data) == 0:
-                pad_data = pd.DataFrame([self.data.iloc[0]] * self.window_size)
+                first_row = self._row_at(0)
+                pad_data = pd.DataFrame([first_row] * self.window_size)
                 window_data = pad_data
             else:
                 # Pad with first available row
                 pad_data = pd.DataFrame([partial_data.iloc[0]] * pad_size)
                 window_data = pd.concat([pad_data, partial_data], axis=0)
         else:
-            # Normal case: slice the window
-            window_data = self.data.iloc[start_idx:end_idx]
-        
+            # Normal case: slice the window via DataSource
+            window_data = self._window_at(start_idx, end_idx)
+
         # Verify we have exactly window_size rows
         if len(window_data) != self.window_size:
             self.logger.warning(
@@ -1059,7 +1093,7 @@ class SingleAssetRLTradingEnv(gym.Env):
             if len(window_data) < self.window_size:
                 # Pad with first row if we don't have enough data
                 pad_size = self.window_size - len(window_data)
-                pad_row = window_data.iloc[0] if len(window_data) > 0 else self.data.iloc[0]
+                pad_row = window_data.iloc[0] if len(window_data) > 0 else self._row_at(0)
                 pad_data = pd.DataFrame([pad_row] * pad_size)
                 window_data = pd.concat([pad_data, window_data], axis=0)
             else:
@@ -1200,10 +1234,10 @@ class SingleAssetRLTradingEnv(gym.Env):
 
     def _calculate_portfolio_value(self, step: int) -> float:
         """Calculate total portfolio value at current step"""
-        if step >= len(self.data):
+        if step >= self._ds_len():
             return self.portfolio_value
-            
-        current_price = self.data.iloc[step]["$close"]
+
+        current_price = self._row_at(step)["$close"]
         position_value = self.current_position * current_price
         return self.current_capital + position_value
 

--- a/tests/data/test_data_sources.py
+++ b/tests/data/test_data_sources.py
@@ -1,0 +1,412 @@
+"""
+Week 62 (S35) — DataSource unit tests:
+  - StaticDataSource
+  - CSVDataSource
+  - MockLiveDataSource
+  - DataQualityGate
+  - Env + MockLiveDataSource integration
+"""
+from __future__ import annotations
+
+import math
+import os
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from data.sources.base import DataSource, StaticDataSource
+from data.sources.csv_source import CSVDataSource
+from data.sources.mock_live_source import MockLiveDataSource
+from data.quality.gate import DataIssue, DataQualityError, DataQualityGate, validate
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ohlcv(n: int = 50, prefix: bool = True) -> pd.DataFrame:
+    """Return a simple deterministic OHLCV DataFrame."""
+    rng = np.random.default_rng(42)
+    prices = 100 + np.cumsum(rng.standard_normal(n))
+    col = "$" if prefix else ""
+    return pd.DataFrame(
+        {
+            f"{col}open": prices,
+            f"{col}high": prices + rng.uniform(0.1, 1.0, n),
+            f"{col}low": prices - rng.uniform(0.1, 1.0, n),
+            f"{col}close": prices + rng.standard_normal(n) * 0.5,
+            f"{col}volume": rng.uniform(100, 1000, n),
+        }
+    )
+
+
+# ===========================================================================
+# StaticDataSource
+# ===========================================================================
+
+class TestStaticDataSource:
+    def test_interface_compliance(self):
+        ds = StaticDataSource(_make_ohlcv())
+        assert isinstance(ds, DataSource)
+
+    def test_len(self):
+        df = _make_ohlcv(30)
+        ds = StaticDataSource(df)
+        assert len(ds) == 30
+
+    def test_is_live_false(self):
+        assert StaticDataSource(_make_ohlcv()).is_live() is False
+
+    def test_get_window_normal(self):
+        df = _make_ohlcv(50)
+        ds = StaticDataSource(df)
+        win = ds.get_window(5, 15)
+        assert len(win) == 10
+        pd.testing.assert_frame_equal(win.reset_index(drop=True), df.iloc[5:15].reset_index(drop=True))
+
+    def test_get_window_full(self):
+        df = _make_ohlcv(20)
+        ds = StaticDataSource(df)
+        win = ds.get_window(0, 20)
+        assert len(win) == 20
+
+    def test_latest(self):
+        df = _make_ohlcv(20)
+        ds = StaticDataSource(df)
+        latest = ds.latest()
+        pd.testing.assert_series_equal(latest, df.iloc[-1])
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            StaticDataSource(pd.DataFrame())
+
+    def test_df_property(self):
+        df = _make_ohlcv()
+        ds = StaticDataSource(df)
+        assert ds.df is not None
+        assert len(ds.df) == len(df)
+
+
+# ===========================================================================
+# CSVDataSource
+# ===========================================================================
+
+class TestCSVDataSource:
+    def _write_csv(self, df: pd.DataFrame, path: str, use_dollar: bool = True) -> None:
+        df.to_csv(path, index=False)
+
+    def test_loads_dollar_prefixed_cols(self, tmp_path):
+        df = _make_ohlcv(30, prefix=True)
+        p = str(tmp_path / "data.csv")
+        df.to_csv(p, index=False)
+        ds = CSVDataSource(p)
+        assert len(ds) == 30
+        assert "$close" in ds.df.columns
+
+    def test_renames_plain_cols(self, tmp_path):
+        df = _make_ohlcv(30, prefix=False)
+        p = str(tmp_path / "plain.csv")
+        df.to_csv(p, index=False)
+        ds = CSVDataSource(p)
+        assert "$close" in ds.df.columns
+        assert "close" not in ds.df.columns
+
+    def test_get_window(self, tmp_path):
+        df = _make_ohlcv(50, prefix=True)
+        p = str(tmp_path / "data.csv")
+        df.to_csv(p, index=False)
+        ds = CSVDataSource(p)
+        win = ds.get_window(10, 20)
+        assert len(win) == 10
+
+    def test_latest(self, tmp_path):
+        df = _make_ohlcv(20, prefix=True)
+        p = str(tmp_path / "data.csv")
+        df.to_csv(p, index=False)
+        ds = CSVDataSource(p)
+        latest = ds.latest()
+        assert latest["$close"] == pytest.approx(df.iloc[-1]["$close"])
+
+    def test_is_live_false(self, tmp_path):
+        df = _make_ohlcv(10, prefix=True)
+        p = str(tmp_path / "data.csv")
+        df.to_csv(p, index=False)
+        assert CSVDataSource(p).is_live() is False
+
+    def test_missing_required_col_raises(self, tmp_path):
+        df = pd.DataFrame({"$open": [1.0], "$close": [1.0]})  # missing others
+        p = str(tmp_path / "bad.csv")
+        df.to_csv(p, index=False)
+        with pytest.raises(ValueError, match="missing required columns"):
+            CSVDataSource(p).get_window(0, 1)
+
+    def test_lazy_load(self, tmp_path):
+        df = _make_ohlcv(10, prefix=True)
+        p = str(tmp_path / "data.csv")
+        df.to_csv(p, index=False)
+        ds = CSVDataSource(p)
+        # File not accessed until first use
+        assert ds._df is None
+        _ = ds.latest()
+        assert ds._df is not None
+
+
+# ===========================================================================
+# MockLiveDataSource
+# ===========================================================================
+
+class TestMockLiveDataSource:
+    def test_is_live_true(self):
+        ds = MockLiveDataSource(_make_ohlcv(20))
+        assert ds.is_live() is True
+
+    def test_len_is_total(self):
+        ds = MockLiveDataSource(_make_ohlcv(20))
+        assert len(ds) == 20
+
+    def test_initial_tick_default(self):
+        ds = MockLiveDataSource(_make_ohlcv(20))
+        assert ds.current_tick == 0
+
+    def test_latest_at_tick(self):
+        df = _make_ohlcv(20)
+        ds = MockLiveDataSource(df)
+        ds.tick(5)
+        assert ds.current_tick == 5
+        pd.testing.assert_series_equal(ds.latest(), df.iloc[5])
+
+    def test_tick_advances(self):
+        ds = MockLiveDataSource(_make_ohlcv(20))
+        ds.tick()
+        ds.tick()
+        ds.tick()
+        assert ds.current_tick == 3
+
+    def test_tick_clamps_at_last_bar(self):
+        ds = MockLiveDataSource(_make_ohlcv(5))
+        ds.tick(100)
+        assert ds.current_tick == 4
+
+    def test_get_window_respects_tick(self):
+        df = _make_ohlcv(20)
+        ds = MockLiveDataSource(df)
+        ds.tick(9)  # tick=9 → visible bars 0..9
+        win = ds.get_window(0, 20)  # request all 20, but only 10 visible
+        assert len(win) == 10
+
+    def test_get_window_within_visible(self):
+        df = _make_ohlcv(20)
+        ds = MockLiveDataSource(df)
+        ds.tick(14)
+        win = ds.get_window(5, 10)
+        assert len(win) == 5
+        pd.testing.assert_frame_equal(
+            win.reset_index(drop=True), df.iloc[5:10].reset_index(drop=True)
+        )
+
+    def test_reset(self):
+        ds = MockLiveDataSource(_make_ohlcv(20))
+        ds.tick(10)
+        ds.reset(3)
+        assert ds.current_tick == 3
+
+    def test_initial_tick_out_of_range_raises(self):
+        with pytest.raises(ValueError):
+            MockLiveDataSource(_make_ohlcv(5), initial_tick=10)
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            MockLiveDataSource(pd.DataFrame())
+
+
+# ===========================================================================
+# DataQualityGate
+# ===========================================================================
+
+class TestDataQualityGate:
+    def test_clean_data_no_issues(self):
+        df = _make_ohlcv(50)
+        issues = validate(df)
+        assert issues == []
+
+    def test_nan_detected(self):
+        df = _make_ohlcv(10)
+        df.iloc[3, df.columns.get_loc("$close")] = float("nan")
+        issues = validate(df)
+        kinds = [i.kind for i in issues]
+        assert "nan_inf" in kinds
+
+    def test_inf_detected(self):
+        df = _make_ohlcv(10)
+        df.iloc[0, df.columns.get_loc("$open")] = math.inf
+        issues = validate(df)
+        assert any(i.kind == "nan_inf" for i in issues)
+
+    def test_negative_price_detected(self):
+        df = _make_ohlcv(10)
+        df.iloc[2, df.columns.get_loc("$close")] = -5.0
+        issues = validate(df)
+        assert any(i.kind == "negative_price" for i in issues)
+
+    def test_zero_volume_detected(self):
+        df = _make_ohlcv(10)
+        df.iloc[5, df.columns.get_loc("$volume")] = 0.0
+        issues = validate(df)
+        assert any(i.kind == "zero_volume" for i in issues)
+
+    def test_check_raises_on_issue(self):
+        df = _make_ohlcv(10)
+        df.iloc[0, df.columns.get_loc("$close")] = float("nan")
+        gate = DataQualityGate()
+        with pytest.raises(DataQualityError) as exc_info:
+            gate.check(df)
+        assert len(exc_info.value.issues) >= 1
+
+    def test_time_gap_detected(self):
+        n = 20
+        df = _make_ohlcv(n)
+        # Add timestamps with a 1-hour frequency, then insert a 10-hour gap at row 10
+        times = pd.date_range("2024-01-01", periods=n, freq="1h")
+        times_list = list(times)
+        times_list[10] = times_list[9] + pd.Timedelta(hours=11)
+        for i in range(11, n):
+            times_list[i] = times_list[i - 1] + pd.Timedelta(hours=1)
+        df["timestamp"] = times_list
+        gate = DataQualityGate(max_gap_bars=5)
+        issues = gate.validate(df)
+        assert any(i.kind == "time_gap" for i in issues)
+
+    def test_no_time_gap_with_regular_timestamps(self):
+        n = 20
+        df = _make_ohlcv(n)
+        df["timestamp"] = pd.date_range("2024-01-01", periods=n, freq="1h")
+        gate = DataQualityGate(max_gap_bars=5)
+        issues = gate.validate(df)
+        assert not any(i.kind == "time_gap" for i in issues)
+
+    def test_multiple_issues_collected(self):
+        df = _make_ohlcv(10)
+        df.iloc[0, df.columns.get_loc("$close")] = float("nan")
+        df.iloc[1, df.columns.get_loc("$open")] = -1.0
+        df.iloc[2, df.columns.get_loc("$volume")] = 0.0
+        issues = validate(df)
+        kinds = {i.kind for i in issues}
+        assert kinds >= {"nan_inf", "negative_price", "zero_volume"}
+
+    def test_issue_str_representation(self):
+        issue = DataIssue(kind="nan_inf", row=5, column="$close", detail="value=nan")
+        s = str(issue)
+        assert "nan_inf" in s
+        assert "row=5" in s
+        assert "$close" in s
+
+
+# ===========================================================================
+# Env + MockLiveDataSource integration (S35)
+# ===========================================================================
+
+class TestEnvWithMockLiveDataSource:
+    """Integration: SingleAssetRLTradingEnv driven by MockLiveDataSource."""
+
+    def _make_env_with_live_ds(self, n: int = 100, window_size: int = 10):
+        from envs.single_asset_rl_env import SingleAssetRLTradingEnv
+
+        df = _make_ohlcv(n)
+        ds = MockLiveDataSource(df)
+        # Advance tick so env has enough history for window
+        ds.tick(n - 1)  # all bars visible from start for simplicity
+        env = SingleAssetRLTradingEnv(
+            data_source=ds,
+            window_size=window_size,
+            initial_capital=10_000,
+        )
+        return env, ds
+
+    def test_env_accepts_mock_live_source(self):
+        env, _ = self._make_env_with_live_ds()
+        assert env.data_source is not None
+        assert env.data_source.is_live() is True
+
+    def test_env_reset_with_live_source(self):
+        env, _ = self._make_env_with_live_ds()
+        obs, info = env.reset()
+        assert obs.shape == (10, 5)
+
+    def test_env_step_returns_valid_obs(self):
+        env, _ = self._make_env_with_live_ds(n=100, window_size=10)
+        env.reset()
+        action = env.action_space.sample()
+        obs, reward, terminated, truncated, info = env.step(action)
+        assert obs.shape == (10, 5)
+        assert isinstance(reward, float)
+        assert not np.isnan(reward)
+
+    def test_observation_changes_with_tick(self):
+        """As tick advances, the observation window should shift."""
+        from envs.single_asset_rl_env import SingleAssetRLTradingEnv
+
+        df = _make_ohlcv(80)
+        ds = MockLiveDataSource(df)
+        ds.tick(79)  # all bars visible
+
+        env = SingleAssetRLTradingEnv(data_source=ds, window_size=5, initial_capital=10_000)
+        obs1, _ = env.reset()
+
+        # Do one step to advance current_step
+        action = env.action_space.sample()
+        obs2, *_ = env.step(action)
+
+        # obs1 and obs2 should differ (different window)
+        assert not np.allclose(obs1, obs2), "Observation should change after step"
+
+    def test_env_uses_ds_len_not_self_data(self):
+        """Env with non-StaticDataSource must work even if self.data is None."""
+        from envs.single_asset_rl_env import SingleAssetRLTradingEnv
+
+        df = _make_ohlcv(60)
+        ds = MockLiveDataSource(df)
+        ds.tick(59)
+
+        env = SingleAssetRLTradingEnv(data_source=ds, window_size=5, initial_capital=10_000)
+        # self.data should be None since ds is not StaticDataSource
+        assert env.data is None
+        # but _ds_len() should work
+        assert env._ds_len() == 60
+
+        obs, _ = env.reset()
+        assert obs.shape == (5, 5)
+
+
+# ===========================================================================
+# DataSource gate integration (gate check before DataSource returns data)
+# ===========================================================================
+
+class TestGateIntegration:
+    def test_gate_rejects_nan_df(self):
+        df = _make_ohlcv(10)
+        df.iloc[2, df.columns.get_loc("$close")] = float("nan")
+        gate = DataQualityGate()
+        with pytest.raises(DataQualityError):
+            gate.check(df)
+
+    def test_csv_source_with_gate_check(self, tmp_path):
+        """CSVDataSource + gate: simulate pre-use validation."""
+        df = _make_ohlcv(20)
+        p = str(tmp_path / "clean.csv")
+        df.to_csv(p, index=False)
+        ds = CSVDataSource(p)
+        gate = DataQualityGate()
+        # Should not raise
+        gate.check(ds.df)
+
+    def test_csv_source_bad_data_raises(self, tmp_path):
+        df = _make_ohlcv(10)
+        df.iloc[0, df.columns.get_loc("$open")] = float("nan")
+        p = str(tmp_path / "bad.csv")
+        df.to_csv(p, index=False)
+        ds = CSVDataSource(p)
+        gate = DataQualityGate()
+        with pytest.raises(DataQualityError):
+            gate.check(ds.df)


### PR DESCRIPTION
## Summary

- **S31**: DataSource ABC 확인 (Week 61 완료 상태)
- **S32**: `CSVDataSource` (lazy CSV load, 컬럼명 자동 정규화) + `MockLiveDataSource` (tick 기반 bar-by-bar 시뮬레이션) 추가
- **S33**: `data/quality/gate.py` — NaN/inf, 음수 가격, zero volume, 시간 gap 검증하는 `DataQualityGate` 구현
- **S34**: `SingleAssetRLTradingEnv` 리팩터 — 모든 `self.data.iloc[step]` / `len(self.data)` 내부 접근을 `_row_at()` / `_ds_len()` / `_window_at()` 헬퍼로 대체. `self.data` 속성은 backward-compat을 위해 유지하나 내부에서 직접 사용 금지
- **S35**: 44개 신규 테스트 (`tests/data/test_data_sources.py`) — 3개 DataSource 구현체, DataQualityGate, Env + MockLiveDataSource 통합 테스트 포함

## Test plan

- [x] `pytest tests/data/test_data_sources.py` — 44 passed
- [x] Full regression: **1558 passed, 0 failed** (baseline 1386 intact)
- [x] `pytest.ini` ignore 목록 미변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)