### PR TITLE
Week 66: P&L Attribution & Latency SLO (S51-S55)

### DIFF
--- a/deployment/analysis/pnl_attribution.py
+++ b/deployment/analysis/pnl_attribution.py
@@ -1,0 +1,220 @@
+"""
+P&L Attribution — Week 66 (S51).
+
+Decomposes each trade's realised P&L into four additive components:
+
+    net_pnl = market_move - slippage_cost - fees
+
+Where:
+    market_move   — gross price-change PnL: (exit_price - entry_price) * qty
+    slippage_cost — execution quality cost (|fill_price - expected_price| / expected_price * qty * price)
+    fees          — total transaction costs paid
+    net_pnl       — model's bottom-line contribution
+
+The decomposition satisfies:
+    market_move = net_pnl + slippage_cost + fees
+
+Usage:
+    from deployment.analysis.pnl_attribution import PnLAttributor
+    from deployment.paper_trader import Trade
+
+    attributor = PnLAttributor()
+    attributions = attributor.attribute(trades, slippage_records=trader._slippage_records)
+    summary = attributor.summarise(attributions)
+    print(summary)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional, Sequence
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TradeAttribution:
+    """Per-trade P&L decomposition."""
+    trade_index: int
+    side: str             # "sell" (only closing trades have realised PnL)
+    entry_price: float
+    exit_price: float
+    quantity: float
+    market_move: float    # (exit_price - entry_price) * quantity  [gross PnL]
+    slippage_cost: float  # execution quality cost  (≥ 0)
+    fees: float           # transaction costs paid  (≥ 0)
+    net_pnl: float        # market_move - slippage_cost - fees
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class AttributionSummary:
+    """Aggregate P&L attribution across all trades."""
+    num_closing_trades: int
+    total_market_move: float
+    total_slippage_cost: float
+    total_fees: float
+    total_net_pnl: float
+    slippage_pct_of_gross: float   # total_slippage_cost / |total_market_move|, 0 if gross==0
+    fees_pct_of_gross: float       # total_fees / |total_market_move|, 0 if gross==0
+
+    # Per-trade averages
+    avg_market_move: float
+    avg_slippage_cost: float
+    avg_fees: float
+    avg_net_pnl: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class PnLAttributor:
+    """
+    Attributes realised P&L to its cost components.
+
+    Parameters
+    ----------
+    fee_bps : float
+        Expected fee in basis-points.  Used only when fee is not directly
+        available on the trade object.  Default = 10 bps (0.1 %).
+    """
+
+    def __init__(self, fee_bps: float = 10.0) -> None:
+        self._fee_bps = fee_bps
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def attribute(
+        self,
+        trades: Sequence,
+        slippage_records: Optional[Sequence[float]] = None,
+        entry_price: Optional[float] = None,
+    ) -> List[TradeAttribution]:
+        """
+        Compute per-trade attribution for a list of Trade objects.
+
+        Parameters
+        ----------
+        trades :
+            List of ``Trade`` dataclass instances from ``deployment.paper_trader``.
+        slippage_records :
+            Optional list of observed slippage fractions
+            (``|fill_price - expected_price| / expected_price``).  Paired
+            with closing trades in order; excess records are ignored.
+        entry_price :
+            Override for the entry price (used when the Trade object doesn't
+            contain it directly — legacy path).  Usually None; the attributor
+            infers entry price from ``trade.pnl``.
+
+        Returns
+        -------
+        List[TradeAttribution]
+            One entry per *closing* (sell) trade with non-zero quantity.
+        """
+        slip_iter = iter(slippage_records or [])
+        results: List[TradeAttribution] = []
+        _last_buy_price: Optional[float] = None
+
+        for idx, trade in enumerate(trades):
+            if trade.side == "buy":
+                _last_buy_price = trade.price
+                continue
+
+            # ----- closing (sell) trade -----
+            qty = float(trade.quantity)
+            if qty < 1e-10:
+                continue
+
+            exit_p = float(trade.price)
+            fee = float(trade.fee)
+
+            # Recover entry_price:
+            #   apply_sell returns pnl = (exit_price - entry_price) * qty
+            #   So entry_price = exit_price - pnl / qty
+            raw_pnl = float(trade.pnl)
+            if abs(qty) > 1e-10 and raw_pnl != 0.0:
+                inferred_entry = exit_p - raw_pnl / qty
+            elif _last_buy_price is not None:
+                inferred_entry = _last_buy_price
+            elif entry_price is not None:
+                inferred_entry = entry_price
+            else:
+                inferred_entry = exit_p  # no info → no market_move
+
+            # Slippage cost: fraction × qty × exit_price
+            slip_frac = next(slip_iter, 0.0)
+            slippage_cost = slip_frac * qty * exit_p
+
+            market_move = (exit_p - inferred_entry) * qty
+            net_pnl = market_move - slippage_cost - fee
+
+            results.append(TradeAttribution(
+                trade_index=idx,
+                side="sell",
+                entry_price=inferred_entry,
+                exit_price=exit_p,
+                quantity=qty,
+                market_move=market_move,
+                slippage_cost=slippage_cost,
+                fees=fee,
+                net_pnl=net_pnl,
+            ))
+
+        return results
+
+    def summarise(self, attributions: List[TradeAttribution]) -> AttributionSummary:
+        """Aggregate attribution list into a summary."""
+        if not attributions:
+            return AttributionSummary(
+                num_closing_trades=0,
+                total_market_move=0.0,
+                total_slippage_cost=0.0,
+                total_fees=0.0,
+                total_net_pnl=0.0,
+                slippage_pct_of_gross=0.0,
+                fees_pct_of_gross=0.0,
+                avg_market_move=0.0,
+                avg_slippage_cost=0.0,
+                avg_fees=0.0,
+                avg_net_pnl=0.0,
+            )
+
+        n = len(attributions)
+        total_mm = sum(a.market_move for a in attributions)
+        total_slip = sum(a.slippage_cost for a in attributions)
+        total_fees = sum(a.fees for a in attributions)
+        total_net = sum(a.net_pnl for a in attributions)
+
+        abs_gross = abs(total_mm)
+        slip_pct = total_slip / abs_gross if abs_gross > 1e-10 else 0.0
+        fees_pct = total_fees / abs_gross if abs_gross > 1e-10 else 0.0
+
+        return AttributionSummary(
+            num_closing_trades=n,
+            total_market_move=total_mm,
+            total_slippage_cost=total_slip,
+            total_fees=total_fees,
+            total_net_pnl=total_net,
+            slippage_pct_of_gross=slip_pct,
+            fees_pct_of_gross=fees_pct,
+            avg_market_move=total_mm / n,
+            avg_slippage_cost=total_slip / n,
+            avg_fees=total_fees / n,
+            avg_net_pnl=total_net / n,
+        )
+
+    def to_exporter_fields(self, summary: AttributionSummary) -> Dict[str, float]:
+        """Return a dict suitable for passing to ``MetricsExporter.update(**fields)``."""
+        return {
+            "pnl_market_move": summary.total_market_move,
+            "pnl_slippage_cost": summary.total_slippage_cost,
+            "pnl_fees": summary.total_fees,
+            "pnl_net": summary.total_net_pnl,
+        }

--- a/deployment/execution/order_manager.py
+++ b/deployment/execution/order_manager.py
@@ -34,6 +34,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, date
 from typing import Any, Dict, List, Optional
 
+import numpy as np
+
 from deployment.execution.position_tracker import PositionTracker
 from deployment.execution.rate_limiter import RateLimiter
 from deployment.execution.fat_finger_guard import FatFingerGuard
@@ -71,6 +73,10 @@ class Order:
     updated_at: datetime = field(default_factory=datetime.utcnow)
     exchange_order_id: Optional[str] = None
     idempotency_key: Optional[str] = None   # S44: duplicate-order prevention
+    # S52: latency timestamps (submit → ack → fill)
+    submitted_at: Optional[datetime] = None   # set in submit_order before execution
+    acked_at: Optional[datetime] = None       # exchange ack (live) or immediate (paper)
+    filled_at: Optional[datetime] = None      # fill completion
 
 
 # ---------------------------------------------------------------------------
@@ -169,6 +175,8 @@ class OrderManager:
         self._daily_pnl: float = 0.0
         self._last_reset_date: date = date.today()
         self._halted: bool = False
+        # S52: latency tracking (submit-to-fill, ms)
+        self._latency_samples: List[float] = []
         self._position_tracker = PositionTracker(
             initial_cash=float(exchange_config.get("initial_cash", 10_000.0))
         )
@@ -289,6 +297,7 @@ class OrderManager:
             current_price = price
 
         order_id = str(uuid.uuid4())[:8]
+        _now = datetime.utcnow()
         order = Order(
             order_id=order_id,
             side=side,
@@ -297,6 +306,7 @@ class OrderManager:
             limit_price=limit_price,
             status="pending",
             idempotency_key=idempotency_key,
+            submitted_at=_now,   # S52: latency start
         )
         with self._lock:
             self._orders[order_id] = order
@@ -316,6 +326,14 @@ class OrderManager:
             order.status = "failed"
             order.updated_at = datetime.utcnow()
             logger.error("Order %s failed: %s", order_id, e)
+
+        # S52: record fill latency (submit → fill)
+        if order.filled_at is not None and order.submitted_at is not None:
+            latency_ms = (
+                (order.filled_at - order.submitted_at).total_seconds() * 1000.0
+            )
+            with self._lock:
+                self._latency_samples.append(latency_ms)
 
         # Audit: fill (or failure) recorded after execution
         if self._audit_logger is not None:
@@ -426,6 +444,23 @@ class OrderManager:
     def is_halted(self) -> bool:
         return self._halted
 
+    def compute_latency_percentiles(self) -> Dict[str, float]:
+        """Return latency percentiles (p50/p95/p99) in milliseconds.
+
+        Computed from all submit-to-fill samples collected since init.
+        Returns zero values if no samples yet.
+        """
+        with self._lock:
+            samples = list(self._latency_samples)
+        if not samples:
+            return {"p50": 0.0, "p95": 0.0, "p99": 0.0, "count": 0.0}
+        return {
+            "p50": float(np.percentile(samples, 50)),
+            "p95": float(np.percentile(samples, 95)),
+            "p99": float(np.percentile(samples, 99)),
+            "count": float(len(samples)),
+        }
+
     @property
     def fat_finger_guard(self) -> FatFingerGuard:
         return self._fat_finger
@@ -518,6 +553,9 @@ class OrderManager:
         if price <= 0:
             price = 1.0
 
+        # S52: paper orders are instant — ack and fill happen together
+        order.acked_at = datetime.utcnow()
+
         if order.side == "buy":
             fee = order.amount * price * 0.001
             self._position_tracker.apply_buy(
@@ -531,6 +569,7 @@ class OrderManager:
             if sell_qty < 1e-9:
                 order.status = "failed"
                 order.updated_at = datetime.utcnow()
+                order.filled_at = order.updated_at
                 return
             proceeds = sell_qty * price
             fee = proceeds * 0.001
@@ -549,6 +588,7 @@ class OrderManager:
 
         order.status = "filled"
         order.updated_at = datetime.utcnow()
+        order.filled_at = order.updated_at   # S52
 
     # ------------------------------------------------------------------
     # Live order execution — S44: idempotency key + improved backoff
@@ -574,12 +614,15 @@ class OrderManager:
                         params=params,
                     )
                 order.exchange_order_id = result.get("id")
+                order.acked_at = datetime.utcnow()   # S52: exchange has the order
                 order.status = "filled" if result.get("status") == "closed" else "pending"
                 order.filled_amount = float(result.get("filled", 0.0))
                 order.avg_fill_price = float(result.get("average") or result.get("price") or 0.0)
                 fee_info = result.get("fee") or {}
                 order.fee = float(fee_info.get("cost", 0.0))
                 order.updated_at = datetime.utcnow()
+                if order.status == "filled":
+                    order.filled_at = order.updated_at   # S52
                 # Update position tracker on successful fill
                 if order.status == "filled" and self._position_tracker is not None:
                     if order.side == "buy":

--- a/deployment/monitoring/metrics_exporter.py
+++ b/deployment/monitoring/metrics_exporter.py
@@ -13,6 +13,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+import numpy as np
+
 logger = logging.getLogger(__name__)
 
 # Try prometheus_client, fallback to in-memory
@@ -43,6 +45,18 @@ class MetricSnapshot:
     current_var: float = 0.0
     daily_pnl: float = 0.0
     is_halted: bool = False
+    # S52: order latency (ms)
+    latency_p50_ms: float = 0.0
+    latency_p95_ms: float = 0.0
+    latency_p99_ms: float = 0.0
+    # S53: rolling performance
+    rolling_sharpe: float = 0.0
+    rolling_sortino: float = 0.0
+    # S51: P&L attribution totals
+    pnl_market_move: float = 0.0
+    pnl_slippage_cost: float = 0.0
+    pnl_fees: float = 0.0
+    pnl_net: float = 0.0
 
 
 class MetricsExporter:
@@ -129,6 +143,57 @@ class MetricsExporter:
 
         return snap
 
+    def update_latency(self, p50: float, p95: float, p99: float) -> MetricSnapshot:
+        """Record order latency percentiles (ms) as a metric update.
+
+        Convenience wrapper so callers don't need to know the field names.
+        """
+        return self.update(
+            latency_p50_ms=float(p50),
+            latency_p95_ms=float(p95),
+            latency_p99_ms=float(p99),
+        )
+
+    def rolling_sharpe(self, window: int = 20, annualize: int = 252) -> float:
+        """Compute rolling Sharpe ratio from the last *window* portfolio-value snapshots.
+
+        Returns 0.0 if insufficient history.
+        """
+        snaps = self.history(last_n=window + 1)
+        if len(snaps) < 2:
+            return 0.0
+        values = np.array([s.portfolio_value for s in snaps], dtype=float)
+        prev = np.where(values[:-1] != 0, values[:-1], 1e-8)
+        returns = np.diff(values) / prev
+        std = np.std(returns)
+        if std < 1e-10:
+            return 0.0
+        return float(np.mean(returns) / std * np.sqrt(annualize))
+
+    def rolling_sortino(
+        self,
+        window: int = 20,
+        annualize: int = 252,
+        mar: float = 0.0,
+    ) -> float:
+        """Compute rolling Sortino ratio from the last *window* portfolio-value snapshots.
+
+        Returns 0.0 if insufficient history.
+        """
+        snaps = self.history(last_n=window + 1)
+        if len(snaps) < 2:
+            return 0.0
+        values = np.array([s.portfolio_value for s in snaps], dtype=float)
+        prev = np.where(values[:-1] != 0, values[:-1], 1e-8)
+        returns = np.diff(values) / prev
+        downside = returns[returns < mar]
+        if len(downside) == 0:
+            return float(np.mean(returns) * np.sqrt(annualize))  # no downside
+        downside_std = float(np.std(downside))
+        if downside_std < 1e-10:
+            return 0.0
+        return float(np.mean(returns) / downside_std * np.sqrt(annualize))
+
     def snapshot(self) -> Optional[MetricSnapshot]:
         """Return latest metric snapshot."""
         return self._latest
@@ -161,4 +226,16 @@ class MetricsExporter:
             "current_var": snap.current_var,
             "daily_pnl": snap.daily_pnl,
             "is_halted": snap.is_halted,
+            # S52
+            "latency_p50_ms": snap.latency_p50_ms,
+            "latency_p95_ms": snap.latency_p95_ms,
+            "latency_p99_ms": snap.latency_p99_ms,
+            # S53
+            "rolling_sharpe": snap.rolling_sharpe,
+            "rolling_sortino": snap.rolling_sortino,
+            # S51
+            "pnl_market_move": snap.pnl_market_move,
+            "pnl_slippage_cost": snap.pnl_slippage_cost,
+            "pnl_fees": snap.pnl_fees,
+            "pnl_net": snap.pnl_net,
         }

--- a/deployment/paper_trader.py
+++ b/deployment/paper_trader.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import numpy as np
 
+from deployment.analysis.pnl_attribution import PnLAttributor
 from deployment.audit.audit_logger import AuditLogger
 from deployment.execution.order_manager import OrderManager
 from deployment.execution.position_tracker import PositionTracker
@@ -828,6 +829,29 @@ class PaperTrader:
             pv = self.state.portfolio_history[-1] if self.state.portfolio_history else self.initial_balance
             peak = self.state.peak_portfolio_value
             dd = (peak - pv) / peak if peak > 0 else 0.0
+
+            # S52: latency percentiles from order_manager
+            latency_kwargs: dict = {}
+            if self.order_manager is not None:
+                lp = self.order_manager.compute_latency_percentiles()
+                latency_kwargs = {
+                    "latency_p50_ms": lp["p50"],
+                    "latency_p95_ms": lp["p95"],
+                    "latency_p99_ms": lp["p99"],
+                }
+
+            # S51: P&L attribution
+            pnl_kwargs: dict = {}
+            closing_trades = [t for t in self.state.trades if t.side == "sell"]
+            if closing_trades:
+                attributor = PnLAttributor()
+                attributions = attributor.attribute(
+                    self.state.trades,
+                    slippage_records=self._slippage_records,
+                )
+                summary = attributor.summarise(attributions)
+                pnl_kwargs = attributor.to_exporter_fields(summary)
+
             self.metrics_exporter.update(
                 portfolio_value=pv,
                 cash=self.state.balance,
@@ -836,7 +860,18 @@ class PaperTrader:
                 num_trades=len(self.state.trades),
                 drift_detected=self.drift_detector.drift_detected if self.drift_detector else False,
                 alerts_fired=len(self.alerter.alert_history) if self.alerter else 0,
+                **latency_kwargs,
+                **pnl_kwargs,
             )
+
+            # S53: rolling Sharpe/Sortino (computed from accumulated history)
+            r_sharpe = self.metrics_exporter.rolling_sharpe(window=20)
+            r_sortino = self.metrics_exporter.rolling_sortino(window=20)
+            if r_sharpe != 0.0 or r_sortino != 0.0:
+                self.metrics_exporter.update(
+                    rolling_sharpe=r_sharpe,
+                    rolling_sortino=r_sortino,
+                )
 
     def _log_final_report(self, report: Dict[str, Any]) -> None:
         try:

--- a/docs/phase6/week66.md
+++ b/docs/phase6/week66.md
@@ -1,0 +1,132 @@
+# Week 66 Retrospective: P&L Attribution & Latency SLO (S51-S55)
+
+**Date**: 2026-04-11  
+**Branch**: claude/wonderful-burnell  
+**Track**: C — Production Safety (final week)
+
+---
+
+## What Was Done
+
+### S51 — PnLAttributor (`deployment/analysis/pnl_attribution.py`)
+
+New module that decomposes each realised trade's P&L into four additive components:
+
+```
+market_move = net_pnl + slippage_cost + fees
+```
+
+- **`market_move`**: `(exit_price - entry_price) × quantity` — pure price direction PnL
+- **`slippage_cost`**: execution quality cost (slip_frac × qty × exit_price)
+- **`fees`**: actual transaction costs paid
+- **`net_pnl`**: bottom-line contribution = `market_move - slippage_cost - fees`
+
+Key design choices:
+- `entry_price` is inferred from `trade.pnl` when available (reverses `apply_sell` formula),
+  falling back to the preceding buy trade price. This avoids needing a separate buy-sell
+  pairing data structure.
+- `PnLAttributor.to_exporter_fields()` returns a dict that can be splatted directly into
+  `MetricsExporter.update(**fields)` — zero coupling.
+- `AttributionSummary` exposes `slippage_pct_of_gross` and `fees_pct_of_gross` for quick
+  quality assessment.
+
+### S52 — Latency Tracking (`deployment/execution/order_manager.py`)
+
+Added to `Order` dataclass:
+- `submitted_at`: timestamp when `submit_order()` is called
+- `acked_at`: exchange ack (paper = immediate)
+- `filled_at`: fill completion
+
+`OrderManager._latency_samples` accumulates submit-to-fill durations (ms).  
+`compute_latency_percentiles()` returns `{p50, p95, p99, count}` via `numpy.percentile`.
+
+Paper mode: all three timestamps collapse to the same instant (sub-millisecond); samples
+are still collected and percentiles remain valid (near-zero).
+
+### S52 — `MetricsExporter.update_latency(p50, p95, p99)`
+
+Convenience wrapper that stores latency percentiles as `MetricSnapshot` fields:
+`latency_p50_ms`, `latency_p95_ms`, `latency_p99_ms`.
+
+### S53 — Rolling Sharpe/Sortino (`deployment/monitoring/metrics_exporter.py`)
+
+- `MetricsExporter.rolling_sharpe(window=20)`: rolling Sharpe from last N portfolio-value
+  snapshots (annualised ×√252).
+- `MetricsExporter.rolling_sortino(window=20)`: uses downside std below `mar=0.0`.
+- Both added as `rolling_sharpe`, `rolling_sortino` fields in `MetricSnapshot`.
+- `PaperTrader._log_step_metrics()` now computes and pushes these every step.
+
+### S54 — `ReconciliationReport.by_order` (`training/analysis/reconciliation.py`)
+
+New `OrderDivergence` dataclass:
+
+```python
+@dataclass
+class OrderDivergence:
+    order_id: str
+    expected_price: float
+    fill_price: float
+    quantity: float
+    slippage: float          # |fill - expected| / expected
+    slippage_cost: float     # directional cost (positive = adverse)
+    side: str
+```
+
+`ReconciliationReport.from_reports()` now accepts optional `orders` and `expected_prices`
+arguments. When present, `by_order` is populated and an `order_avg_slippage` delta is
+added. Warning fires if avg order-level slippage > 0.2%.
+
+Backward compat: callers passing no `orders` get `by_order=[]` as before.
+
+### Wiring into PaperTrader
+
+`_log_step_metrics()` now orchestrates:
+1. Attribution via `PnLAttributor` on all current trades
+2. Latency via `order_manager.compute_latency_percentiles()`
+3. Rolling Sharpe/Sortino via `metrics_exporter.rolling_sharpe/sortino()`
+
+All fields flow into `MetricsExporter` and are exposed via `to_json()` / dashboard.
+
+---
+
+## Test Coverage (S55)
+
+`tests/deployment/test_pnl_attribution.py` — 33 tests, 0 failures:
+
+| Class | Tests |
+|---|---|
+| `TestPnLAttributor` | decomposition sum check, slippage, edge cases, summary |
+| `TestMetricsExporterWeek66` | defaults, latency, rolling metrics, backward compat, thread-safety |
+| `TestOrderManagerLatency` | empty, fill recording, accumulation, `filled_at`, rejected orders |
+| `TestReconciliationByOrder` | empty, populated, sign, JSON, warning, backward compat |
+| `TestPnLAttributionIntegration` | sum matches trade PnL, net = market_move - costs |
+
+---
+
+## Gotchas
+
+1. **`VolatilityCircuitBreaker` validation**: `vol_threshold > 0` and `window >= 2` are
+   hard requirements. Test must feed `window+1` prices to produce ddof=1 std (need ≥2 returns).
+
+2. **`entry_price` inference**: In paper mode `trade.pnl` is the gross price-change PnL
+   (before fees, from `PositionTracker.apply_sell`). So `entry_price = exit_price - pnl/qty`.
+   This breaks for partial fills where multiple buys exist — production data should store
+   VWAP entry explicitly.
+
+3. **Rolling metrics in `_log_step_metrics`**: the method is only called when
+   `mlflow_manager` is set. If you run PaperTrader without MLflow, rolling metrics
+   still work via `metrics_exporter.rolling_sharpe()` as a query method — they just
+   won't be automatically pushed each step.
+
+4. **Latency in paper mode**: all latencies are < 1 ms. percentiles are technically
+   correct but not meaningful for SLO enforcement. Enforcement is a live-mode concern;
+   this implementation is the measurement foundation.
+
+---
+
+## Phase 7 Candidates (out of scope here)
+
+- SLO alerting: `p99 > N ms → audit event + halt`
+- Live-mode `acked_at` tracking (currently set immediately for paper)
+- Attribution against a passive benchmark (buy-and-hold baseline)
+- `PnLAttributor` integration into `ReconciliationReport.from_reports()`

--- a/tests/deployment/test_pnl_attribution.py
+++ b/tests/deployment/test_pnl_attribution.py
@@ -1,0 +1,454 @@
+"""
+Week 66 tests — S55: P&L Attribution & Latency SLO.
+
+Covers:
+  - PnLAttributor: decomposition correctness (sum check), edge cases
+  - MetricsExporter: latency fields, rolling Sharpe/Sortino, new PnL fields, backward compat
+  - OrderManager: latency sample collection, compute_latency_percentiles()
+  - ReconciliationReport: by_order / OrderDivergence population
+"""
+from __future__ import annotations
+
+import time
+import threading
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _Trade:
+    side: str
+    price: float
+    quantity: float
+    fee: float
+    pnl: float = 0.0
+    timestamp: datetime = None
+
+    def __post_init__(self):
+        if self.timestamp is None:
+            self.timestamp = datetime.utcnow()
+
+
+@dataclass
+class _Order:
+    order_id: str
+    side: str
+    amount: float
+    avg_fill_price: float
+    filled_amount: float = 0.0
+    status: str = "filled"
+
+
+# ---------------------------------------------------------------------------
+# S51: PnLAttributor
+# ---------------------------------------------------------------------------
+
+class TestPnLAttributor:
+    def _make_attributor(self):
+        from deployment.analysis.pnl_attribution import PnLAttributor
+        return PnLAttributor()
+
+    def test_no_trades_returns_empty(self):
+        attr = self._make_attributor()
+        result = attr.attribute([])
+        assert result == []
+
+    def test_only_buy_trades_returns_empty(self):
+        attr = self._make_attributor()
+        trades = [_Trade("buy", 100.0, 1.0, 0.1)]
+        result = attr.attribute(trades)
+        assert result == []
+
+    def test_single_round_trip_sum_check(self):
+        """market_move = net_pnl + slippage_cost + fees"""
+        attr = self._make_attributor()
+        # buy at 100, sell at 110, qty=1, fee=0.11 (0.1%), pnl=(110-100)*1=10
+        entry_price = 100.0
+        exit_price = 110.0
+        qty = 1.0
+        fee = exit_price * qty * 0.001  # 0.11
+        raw_pnl = (exit_price - entry_price) * qty  # 10.0
+
+        buy_trade = _Trade("buy", entry_price, qty, fee=entry_price * qty * 0.001)
+        sell_trade = _Trade("sell", exit_price, qty, fee=fee, pnl=raw_pnl)
+        trades = [buy_trade, sell_trade]
+
+        result = attr.attribute(trades)
+        assert len(result) == 1
+        a = result[0]
+
+        # Decomposition sum check: market_move = net_pnl + slippage_cost + fees
+        assert abs(a.market_move - (a.net_pnl + a.slippage_cost + a.fees)) < 1e-8
+
+    def test_slippage_applied_correctly(self):
+        attr = self._make_attributor()
+        exit_price = 110.0
+        qty = 2.0
+        fee = 0.22
+        raw_pnl = 20.0  # (110-100)*2
+
+        sell_trade = _Trade("sell", exit_price, qty, fee=fee, pnl=raw_pnl)
+        slip_frac = 0.005  # 0.5%
+
+        result = attr.attribute([sell_trade], slippage_records=[slip_frac])
+        assert len(result) == 1
+        a = result[0]
+
+        expected_slip_cost = slip_frac * qty * exit_price
+        assert abs(a.slippage_cost - expected_slip_cost) < 1e-8
+        assert abs(a.net_pnl - (a.market_move - a.slippage_cost - a.fees)) < 1e-8
+
+    def test_zero_slippage_in_paper_mode(self):
+        """No slippage records → slippage_cost == 0."""
+        attr = self._make_attributor()
+        sell_trade = _Trade("sell", 110.0, 1.0, fee=0.11, pnl=10.0)
+        result = attr.attribute([sell_trade])
+        assert result[0].slippage_cost == 0.0
+
+    def test_multiple_round_trips_sum_check(self):
+        attr = self._make_attributor()
+        trades = []
+        for i in range(5):
+            entry = 100.0 + i * 10
+            exit_p = entry + 5.0
+            qty = 0.5
+            fee = exit_p * qty * 0.001
+            trades.append(_Trade("buy", entry, qty, fee=entry * qty * 0.001))
+            trades.append(_Trade("sell", exit_p, qty, fee=fee, pnl=(exit_p - entry) * qty))
+
+        result = attr.attribute(trades)
+        assert len(result) == 5
+        for a in result:
+            assert abs(a.market_move - (a.net_pnl + a.slippage_cost + a.fees)) < 1e-8
+
+    def test_summarise_zero_trades(self):
+        attr = self._make_attributor()
+        summary = attr.summarise([])
+        assert summary.num_closing_trades == 0
+        assert summary.total_net_pnl == 0.0
+        assert summary.slippage_pct_of_gross == 0.0
+
+    def test_summarise_totals(self):
+        attr = self._make_attributor()
+        sell_trade = _Trade("sell", 110.0, 1.0, fee=0.11, pnl=10.0)
+        attributions = attr.attribute([sell_trade], slippage_records=[0.001])
+        summary = attr.summarise(attributions)
+
+        assert summary.num_closing_trades == 1
+        assert abs(summary.total_market_move - attributions[0].market_move) < 1e-8
+        assert abs(summary.total_fees - attributions[0].fees) < 1e-8
+
+    def test_to_exporter_fields(self):
+        from deployment.analysis.pnl_attribution import PnLAttributor
+        attr = PnLAttributor()
+        sell_trade = _Trade("sell", 110.0, 1.0, fee=0.11, pnl=10.0)
+        summary = attr.summarise(attr.attribute([sell_trade]))
+        fields = attr.to_exporter_fields(summary)
+        assert "pnl_market_move" in fields
+        assert "pnl_slippage_cost" in fields
+        assert "pnl_fees" in fields
+        assert "pnl_net" in fields
+
+
+# ---------------------------------------------------------------------------
+# S52 / S53: MetricsExporter latency + rolling metrics
+# ---------------------------------------------------------------------------
+
+class TestMetricsExporterWeek66:
+    def _make_exporter(self):
+        from deployment.monitoring.metrics_exporter import MetricsExporter
+        return MetricsExporter()
+
+    def test_new_snapshot_fields_have_defaults(self):
+        exp = self._make_exporter()
+        snap = exp.update(portfolio_value=10000.0)
+        assert snap.latency_p50_ms == 0.0
+        assert snap.latency_p95_ms == 0.0
+        assert snap.latency_p99_ms == 0.0
+        assert snap.rolling_sharpe == 0.0
+        assert snap.rolling_sortino == 0.0
+        assert snap.pnl_market_move == 0.0
+        assert snap.pnl_net == 0.0
+
+    def test_update_latency_stores_values(self):
+        exp = self._make_exporter()
+        snap = exp.update_latency(p50=12.5, p95=45.0, p99=120.0)
+        assert snap.latency_p50_ms == 12.5
+        assert snap.latency_p95_ms == 45.0
+        assert snap.latency_p99_ms == 120.0
+
+    def test_update_latency_preserves_existing_fields(self):
+        exp = self._make_exporter()
+        exp.update(portfolio_value=99000.0, num_trades=5)
+        snap = exp.update_latency(p50=10.0, p95=20.0, p99=30.0)
+        assert snap.portfolio_value == 99000.0
+        assert snap.num_trades == 5
+
+    def test_rolling_sharpe_insufficient_history(self):
+        exp = self._make_exporter()
+        assert exp.rolling_sharpe(window=20) == 0.0
+
+    def test_rolling_sharpe_positive_trend(self):
+        exp = self._make_exporter()
+        # Feed increasing portfolio values → positive returns → positive Sharpe
+        for i in range(30):
+            exp.update(portfolio_value=10000.0 + i * 50.0)
+        sharpe = exp.rolling_sharpe(window=20)
+        assert sharpe > 0.0
+
+    def test_rolling_sortino_insufficient_history(self):
+        exp = self._make_exporter()
+        assert exp.rolling_sortino(window=20) == 0.0
+
+    def test_rolling_sortino_no_downside(self):
+        exp = self._make_exporter()
+        for i in range(30):
+            exp.update(portfolio_value=10000.0 + i * 100.0)
+        sortino = exp.rolling_sortino(window=20)
+        # monotonically increasing → no downside → high sortino
+        assert sortino != 0.0
+
+    def test_rolling_sharpe_negative_trend(self):
+        exp = self._make_exporter()
+        for i in range(30):
+            exp.update(portfolio_value=10000.0 - i * 20.0)
+        sharpe = exp.rolling_sharpe(window=20)
+        assert sharpe < 0.0
+
+    def test_pnl_attribution_fields_exposed_in_to_json(self):
+        exp = self._make_exporter()
+        snap = exp.update(pnl_market_move=500.0, pnl_slippage_cost=5.0, pnl_fees=2.5, pnl_net=492.5)
+        data = exp.to_json()
+        assert data["pnl_market_move"] == 500.0
+        assert data["pnl_slippage_cost"] == 5.0
+        assert data["pnl_net"] == 492.5
+
+    def test_existing_fields_still_present_in_to_json(self):
+        """Backward-compat: old fields must not disappear."""
+        exp = self._make_exporter()
+        exp.update(portfolio_value=12000.0, sharpe_ratio=1.5, is_halted=False)
+        data = exp.to_json()
+        for key in ("portfolio_value", "cash", "position", "unrealised_pnl",
+                    "realised_pnl", "drawdown_pct", "num_trades", "win_rate",
+                    "sharpe_ratio", "drift_detected", "alerts_fired",
+                    "current_var", "daily_pnl", "is_halted"):
+            assert key in data, f"Missing key: {key}"
+
+    def test_thread_safe_update_latency(self):
+        exp = self._make_exporter()
+        results = []
+        def worker():
+            for _ in range(100):
+                snap = exp.update_latency(p50=1.0, p95=2.0, p99=3.0)
+                results.append(snap)
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(results) == 500
+
+
+# ---------------------------------------------------------------------------
+# S52: OrderManager latency tracking
+# ---------------------------------------------------------------------------
+
+class TestOrderManagerLatency:
+    def _make_manager(self):
+        from deployment.execution.order_manager import OrderManager
+        return OrderManager(paper_mode=True)
+
+    def test_latency_percentiles_empty(self):
+        mgr = self._make_manager()
+        result = mgr.compute_latency_percentiles()
+        assert result["p50"] == 0.0
+        assert result["p95"] == 0.0
+        assert result["p99"] == 0.0
+        assert result["count"] == 0.0
+
+    def test_latency_recorded_after_fill(self):
+        mgr = self._make_manager()
+        mgr.update_paper_price(100.0)
+        oid = mgr.submit_order("buy", 0.5, current_price=100.0)
+        assert mgr.check_order(oid) == "filled"
+        result = mgr.compute_latency_percentiles()
+        assert result["count"] == 1.0
+        assert result["p50"] >= 0.0   # paper mode = near-zero latency
+
+    def test_multiple_fills_accumulate(self):
+        mgr = self._make_manager()
+        mgr.update_paper_price(100.0)
+        for _ in range(10):
+            mgr.submit_order("buy", 0.01, current_price=100.0)
+        result = mgr.compute_latency_percentiles()
+        assert result["count"] == 10.0
+
+    def test_filled_at_set_on_paper_order(self):
+        from deployment.execution.order_manager import OrderManager
+        mgr = OrderManager(paper_mode=True)
+        mgr.update_paper_price(50.0)
+        oid = mgr.submit_order("buy", 0.1, current_price=50.0)
+        order = mgr.get_order(oid)
+        assert order.filled_at is not None
+        assert order.submitted_at is not None
+        assert order.filled_at >= order.submitted_at
+
+    def test_rejected_order_no_latency_sample(self):
+        """Rejected orders (status=failed) should not contribute latency samples."""
+        from deployment.execution.order_manager import OrderManager
+        from deployment.execution.circuit_breaker import VolatilityCircuitBreaker
+        # Force circuit breaker to trip: very low threshold + large price moves
+        # window=2 needs 3 prices (window+1) for ddof=1 std calculation
+        cb = VolatilityCircuitBreaker(vol_threshold=0.001, window=2, cooldown=9999.0)
+        cb.update(100.0)
+        cb.update(150.0)  # +50%
+        cb.update(80.0)   # -47%
+        assert cb.is_tripped()
+        mgr = OrderManager(paper_mode=True, circuit_breaker=cb)
+        mgr.update_paper_price(100.0)
+        oid = mgr.submit_order("buy", 0.1, current_price=100.0)
+        assert mgr.check_order(oid) == "failed"
+        result = mgr.compute_latency_percentiles()
+        assert result["count"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# S54: ReconciliationReport.by_order / OrderDivergence
+# ---------------------------------------------------------------------------
+
+class TestReconciliationByOrder:
+    def _base_reports(self):
+        bt = {
+            "total_return": 0.05,
+            "sharpe_ratio": 1.0,
+            "sortino_ratio": 1.2,
+            "max_drawdown": 0.02,
+            "num_trades": 10,
+            "win_rate": 0.6,
+            "total_fees": 50.0,
+            "avg_fill_slippage": 0.001,
+            "final_portfolio_value": 10500.0,
+        }
+        live = dict(bt)
+        live["total_return"] = 0.045
+        live["avg_fill_slippage"] = 0.0015
+        return bt, live
+
+    def test_by_order_empty_when_no_orders(self):
+        from training.analysis.reconciliation import ReconciliationReport
+        bt, live = self._base_reports()
+        report = ReconciliationReport.from_reports(bt, live)
+        assert report.by_order == []
+
+    def test_by_order_populated(self):
+        from training.analysis.reconciliation import ReconciliationReport
+        bt, live = self._base_reports()
+        orders = [
+            _Order("o1", "buy",  1.0, avg_fill_price=100.5, filled_amount=1.0),
+            _Order("o2", "sell", 1.0, avg_fill_price=109.3, filled_amount=1.0),
+        ]
+        expected_prices = [100.0, 110.0]
+        report = ReconciliationReport.from_reports(
+            bt, live, orders=orders, expected_prices=expected_prices
+        )
+        assert len(report.by_order) == 2
+        d0 = report.by_order[0]
+        assert d0.order_id == "o1"
+        assert abs(d0.slippage - abs(100.5 - 100.0) / 100.0) < 1e-8
+        assert d0.side == "buy"
+
+    def test_order_divergence_slippage_cost_sign(self):
+        """Buy: overpaid → positive cost. Sell: underpaid → positive cost."""
+        from training.analysis.reconciliation import ReconciliationReport
+        bt, live = self._base_reports()
+        # Buy filled 1% above expected → cost > 0
+        buy_order = _Order("o1", "buy", 1.0, avg_fill_price=101.0, filled_amount=1.0)
+        report = ReconciliationReport.from_reports(
+            bt, live, orders=[buy_order], expected_prices=[100.0]
+        )
+        d = report.by_order[0]
+        assert d.slippage_cost > 0.0  # overpaid
+
+    def test_to_json_includes_by_order(self):
+        from training.analysis.reconciliation import ReconciliationReport
+        bt, live = self._base_reports()
+        orders = [_Order("o1", "buy", 1.0, avg_fill_price=100.5, filled_amount=1.0)]
+        report = ReconciliationReport.from_reports(
+            bt, live, orders=orders, expected_prices=[100.0]
+        )
+        data = report.to_json()
+        assert "by_order" in data
+        assert len(data["by_order"]) == 1
+        assert data["by_order"][0]["order_id"] == "o1"
+
+    def test_by_order_warning_on_high_slippage(self):
+        from training.analysis.reconciliation import ReconciliationReport
+        bt, live = self._base_reports()
+        # 5% slippage → should trigger warning
+        orders = [_Order("o1", "buy", 1.0, avg_fill_price=105.0, filled_amount=1.0)]
+        report = ReconciliationReport.from_reports(
+            bt, live, orders=orders, expected_prices=[100.0]
+        )
+        assert any("slippage" in w.lower() for w in report.warnings)
+
+    def test_backward_compat_no_orders_param(self):
+        """Old callers that pass no orders must still work."""
+        from training.analysis.reconciliation import ReconciliationReport
+        bt, live = self._base_reports()
+        report = ReconciliationReport.from_reports(bt, live)
+        assert isinstance(report, ReconciliationReport)
+        assert report.by_order == []
+
+
+# ---------------------------------------------------------------------------
+# S55: integration — PnL attribution total equals paper trader PnL
+# ---------------------------------------------------------------------------
+
+class TestPnLAttributionIntegration:
+    """Verify that attribution sum equals observed PnL from PaperTrader."""
+
+    def test_attribution_sum_matches_total_pnl(self):
+        """sum(trade.pnl) ≈ sum(attribution.market_move) for sell trades."""
+        from deployment.analysis.pnl_attribution import PnLAttributor
+
+        # Simulate a set of trades manually
+        trades = []
+        for i in range(8):
+            entry = 1000.0 + i * 5
+            exit_p = entry + (3.0 if i % 2 == 0 else -1.0)
+            qty = 1.0
+            raw_pnl = (exit_p - entry) * qty
+            buy_fee = entry * qty * 0.001
+            sell_fee = exit_p * qty * 0.001
+            trades.append(_Trade("buy", entry, qty, fee=buy_fee))
+            trades.append(_Trade("sell", exit_p, qty, fee=sell_fee, pnl=raw_pnl))
+
+        attr = PnLAttributor()
+        attributions = attr.attribute(trades)
+        summary = attr.summarise(attributions)
+
+        # Selling trades: sum of raw_pnl
+        expected_market_move = sum(t.pnl for t in trades if t.side == "sell")
+        assert abs(summary.total_market_move - expected_market_move) < 1e-6
+
+    def test_net_pnl_equals_market_move_minus_costs(self):
+        from deployment.analysis.pnl_attribution import PnLAttributor
+        slip = [0.001, 0.002]
+        trades = [
+            _Trade("buy",  100.0, 1.0, fee=0.1),
+            _Trade("sell", 110.0, 1.0, fee=0.11, pnl=10.0),
+            _Trade("buy",  115.0, 1.0, fee=0.115),
+            _Trade("sell", 120.0, 1.0, fee=0.12, pnl=5.0),
+        ]
+        attr = PnLAttributor()
+        attributions = attr.attribute(trades, slippage_records=slip)
+        for a in attributions:
+            expected_net = a.market_move - a.slippage_cost - a.fees
+            assert abs(a.net_pnl - expected_net) < 1e-8

--- a/training/analysis/reconciliation.py
+++ b/training/analysis/reconciliation.py
@@ -17,10 +17,26 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field, asdict
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Sequence
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OrderDivergence:
+    """Per-order slippage decomposition (S54).
+
+    Represents the difference between the expected execution price
+    (the market price at decision time) and the actual fill price.
+    """
+    order_id: str
+    expected_price: float       # market price when order was submitted
+    fill_price: float           # actual avg fill price
+    quantity: float
+    slippage: float             # |fill_price - expected_price| / expected_price
+    slippage_cost: float        # slippage * quantity * expected_price (sign: negative = cost)
+    side: str = ""              # "buy" | "sell"
 
 
 @dataclass
@@ -48,12 +64,15 @@ class ReconciliationReport:
     live: NormalisedMetrics
     deltas: Dict[str, float] = field(default_factory=dict)
     warnings: list = field(default_factory=list)
+    by_order: List[OrderDivergence] = field(default_factory=list)  # S54
 
     @classmethod
     def from_reports(
         cls,
         backtest_report: Dict[str, Any],
         live_report: Dict[str, Any],
+        orders: Optional[Sequence] = None,      # S54: list of Order objects
+        expected_prices: Optional[Sequence[float]] = None,  # S54: paired with orders
     ) -> "ReconciliationReport":
         """Create reconciliation from two report dicts.
 
@@ -103,7 +122,41 @@ class ReconciliationReport:
                 f"High live slippage: {lv.avg_fill_slippage:.4%}"
             )
 
-        return cls(backtest=bt, live=lv, deltas=deltas, warnings=warnings)
+        # S54: order-level slippage decomposition
+        by_order: List[OrderDivergence] = []
+        if orders is not None:
+            prices = list(expected_prices) if expected_prices is not None else []
+            for i, order in enumerate(orders):
+                fill_price = float(getattr(order, "avg_fill_price", 0.0))
+                expected = prices[i] if i < len(prices) else fill_price
+                qty = float(getattr(order, "filled_amount", getattr(order, "amount", 0.0)))
+                if expected <= 0 or qty <= 0:
+                    continue
+                slip_frac = abs(fill_price - expected) / expected
+                # positive = unfavourable (overpaid on buy, underpaid on sell)
+                side = getattr(order, "side", "")
+                if side == "buy":
+                    slip_cost = (fill_price - expected) * qty
+                else:
+                    slip_cost = (expected - fill_price) * qty
+                by_order.append(OrderDivergence(
+                    order_id=str(getattr(order, "order_id", i)),
+                    expected_price=expected,
+                    fill_price=fill_price,
+                    quantity=qty,
+                    slippage=slip_frac,
+                    slippage_cost=slip_cost,
+                    side=side,
+                ))
+            if by_order:
+                avg_order_slip = sum(d.slippage for d in by_order) / len(by_order)
+                deltas["order_avg_slippage"] = avg_order_slip
+                if avg_order_slip > 0.002:
+                    warnings.append(
+                        f"Order-level avg slippage > 0.2%: {avg_order_slip:.4%}"
+                    )
+
+        return cls(backtest=bt, live=lv, deltas=deltas, warnings=warnings, by_order=by_order)
 
     @staticmethod
     def _normalise(report: Dict[str, Any], source: str) -> NormalisedMetrics:
@@ -164,6 +217,7 @@ class ReconciliationReport:
             "live": asdict(self.live),
             "deltas": self.deltas,
             "warnings": self.warnings,
+            "by_order": [asdict(d) for d in self.by_order],  # S54
         }
         if path:
             Path(path).write_text(json.dumps(data, indent=2))


### PR DESCRIPTION
## Summary

- **S51** `deployment/analysis/pnl_attribution.py` — `PnLAttributor` decomposes each trade PnL into `market_move / slippage_cost / fees / net_pnl` with sum invariant `market_move = net_pnl + slippage_cost + fees`
- **S52** `OrderManager` latency timestamps (`submitted_at / acked_at / filled_at`), `compute_latency_percentiles()`, `MetricsExporter.update_latency(p50, p95, p99)`
- **S53** `MetricsExporter.rolling_sharpe(window)` / `rolling_sortino(window)` — live rolling performance exposed in `MetricSnapshot` + dashboard
- **S54** `ReconciliationReport.by_order: list[OrderDivergence]` — per-order slippage decomposition; backward-compat (no orders → empty list)
- **Wiring** `PaperTrader._log_step_metrics()` pushes attribution + latency + rolling metrics every step

## Test plan

- [x] `tests/deployment/test_pnl_attribution.py` — 33 new tests (all passing)
  - `TestPnLAttributor` — sum check, slippage, edge cases
  - `TestMetricsExporterWeek66` — defaults, latency, rolling metrics, backward compat, thread-safety
  - `TestOrderManagerLatency` — fill recording, accumulation, `filled_at`, rejected orders
  - `TestReconciliationByOrder` — populated, sign, JSON, warning, backward compat
  - `TestPnLAttributionIntegration` — sum matches trade PnL
- [x] Full regression: **1700 passed, 19 skipped, 0 failed**
- [x] Existing `MetricsExporter` fields preserved (`test_existing_fields_still_present_in_to_json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)