### PR TITLE
Week 68: Rollback / Shadow Deploy & Final Validation (S61-S65)

### DIFF
--- a/deployment/audit/audit_logger.py
+++ b/deployment/audit/audit_logger.py
@@ -84,7 +84,12 @@ class AuditLogger:
         """Record a risk management event (kill-switch, drawdown breach, etc.)."""
         self._write("risk_event", dict(event))
 
-    def log_model_decision(self, action: Any, obs_hash: str) -> None:
+    def log_model_decision(
+        self,
+        action: Any,
+        obs_hash: str,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Record a model decision.
 
         Parameters
@@ -93,11 +98,16 @@ class AuditLogger:
             The action chosen by the model.
         obs_hash : str
             sha256 hex digest of the observation (use sha256(obs.tobytes())).
+        extra : dict, optional
+            Additional metadata (e.g. shadow comparison fields). Keys must be
+            JSON-serialisable.
         """
-        payload = {
+        payload: Dict[str, Any] = {
             "action": action if isinstance(action, (int, float, str)) else list(action),
             "obs_hash": obs_hash,
         }
+        if extra:
+            payload.update(extra)
         self._write("model_decision", payload)
 
     def close(self) -> None:

--- a/deployment/paper_trader.py
+++ b/deployment/paper_trader.py
@@ -234,9 +234,12 @@ class PaperTrader:
         state_store: Optional[StateStore] = None,
         audit_logger: Optional[AuditLogger] = None,
         data_source=None,
+        shadow_agent=None,
     ) -> None:
         self.agent = agent
         self.config = config
+        # Phase 6 Week 68 (S61): optional shadow agent — observes only, no orders.
+        self.shadow_agent = shadow_agent
         self.mlflow_manager = mlflow_manager
         self.simulation_mode = simulation_mode
         self.alerter = alerter
@@ -366,6 +369,7 @@ class PaperTrader:
             self._execute_action(action, price)
             self._check_risk(price)
             self._check_drift()
+            self._run_shadow_agent(obs, step)
             self._maybe_daily_report()
 
             step += 1
@@ -723,6 +727,49 @@ class PaperTrader:
             self._execute_sell(1.0, self.state._current_price)
         self.state.shutdown_triggered = True
         self.state.shutdown_reason = reason
+
+    # ------------------------------------------------------------------
+    # Phase 6 Week 68 (S61): Shadow agent
+    # ------------------------------------------------------------------
+
+    def _run_shadow_agent(self, obs: np.ndarray, step: int) -> None:
+        """S61: Run shadow_agent prediction without executing any orders.
+
+        The shadow agent observes the same state as the main agent but its
+        decisions are only recorded to the audit log for post-hoc comparison.
+        """
+        if self.shadow_agent is None:
+            return
+        try:
+            shadow_action, _ = self.shadow_agent.predict(obs, deterministic=True)
+            if isinstance(shadow_action, np.ndarray):
+                shadow_action_val = float(shadow_action.flat[0])
+            else:
+                shadow_action_val = float(shadow_action)
+            main_action, _ = self.agent.predict(obs, deterministic=True)
+            if isinstance(main_action, np.ndarray):
+                main_action_val = float(main_action.flat[0])
+            else:
+                main_action_val = float(main_action)
+            logger.debug(
+                "shadow step=%d main_action=%.4f shadow_action=%.4f",
+                step, main_action_val, shadow_action_val,
+            )
+            if self.audit_logger is not None:
+                import hashlib
+                obs_hash = hashlib.sha256(obs.tobytes()).hexdigest()
+                self.audit_logger.log_model_decision(
+                    action=shadow_action_val,
+                    obs_hash=obs_hash,
+                    extra={
+                        "source": "shadow",
+                        "step": step,
+                        "main_action": main_action_val,
+                        "shadow_action": shadow_action_val,
+                    },
+                )
+        except Exception as e:
+            logger.warning("Shadow agent step failed at step=%d: %s", step, e)
 
     # ------------------------------------------------------------------
     # Phase 6 Week 65 helpers

--- a/docs/phase6/RETRO.md
+++ b/docs/phase6/RETRO.md
@@ -1,0 +1,98 @@
+# Phase 6 Retrospective: Production Readiness & Architecture Consolidation
+
+**기간**: Weeks 56-68 (2026-03-xx ~ 2026-04-12)  
+**목표**: "돈 태울 수 있는 상태" — ops readiness + 구조 통합
+
+---
+
+## 최종 테스트 결과
+
+**1727 passed, 19 skipped, 0 failed**  
+Phase 5 baseline: 1386 → Phase 6 완료: 1727 (+341 신규 테스트)
+
+---
+
+## Track A — Ops Readiness (Weeks 56-59)
+
+### 배운 것
+- **StateStore**: SQLite WAL 모드 + idempotent restore는 간단하지만 강력하다. `PRAGMA journal_mode=WAL`만으로 동시 read/write 충돌 해결.
+- **AuditLogger**: hash chain이 append-only 보장의 핵심. 파일 corruption 감지는 verify_audit_log.py 하나로 충분.
+- **Secrets**: `secret_ref:` 패턴 — config에서 평문 제거하는 가장 덜 침습적 방법. 실 운영에서 env var 기반이 macOS keychain보다 CI/CD 친화적.
+- **Runbook + Drills**: 코드보다 운영 절차가 위기 대응의 핵심. drill script가 실제 failure path를 커버해야 진짜 가치.
+
+### Gotchas
+- StateStore `PRAGMA journal_mode=WAL` 설정은 `PRAGMA` 구문으로 해야 하며, connection string에 포함하면 동작 안 함.
+- Audit chain replay 시 partial write (크래시 직전) 레코드가 있으면 chain이 끊긴다. verify script는 이를 exit 1로 감지.
+
+---
+
+## Track B — Architecture Consolidation (Weeks 60-63)
+
+### 배운 것
+- **UnifiedRiskManager**: composition 방식(기존 클래스가 내부에서 사용)이 subclassing보다 안전했다. 기존 1386 테스트 건드리지 않고 통합 완료.
+- **DataSource**: 인터페이스 분리 효과가 즉각적 — `StaticDataSource` / `CSVDataSource` / `MockLiveDataSource` 각각 독립 테스트 가능.
+- **Config Consolidation**: 23개 → 10개 YAML. `load(env)` 하나로 merge + validate. `_deep_merge` 구현이 제일 까다로웠음.
+- **DI (Dependency Injection)**: `PaperTrader`에 주입 포인트를 많이 만들어두면 테스트 작성이 쉬워진다. 하지만 constructor가 너무 길어지는 trade-off.
+
+### Gotchas
+- `UnifiedRiskManager`와 `RiskManagerBase`는 interface가 다르다 (예: `check_max_drawdown` vs `check_drawdown`). Phase 7에서 통합 필요.
+- Config merge 시 list 타입 값은 deep merge 안 하고 override함 — 의도된 동작이지만 주의.
+
+---
+
+## Track C — Production Safety (Weeks 64-66)
+
+### 배운 것
+- **Fat-finger guard**: `lookback` 기반 평균 × multiplier 체크가 hard cap보다 시장 적응적. 초기에 history가 없으면 hard cap만 동작.
+- **Circuit breaker**: rolling vol이 `window` 미만이면 trip 안 함. cooldown 설정이 false alarm 방지에 중요.
+- **Rate limiter**: 토큰 버킷(token bucket)은 간단하지만 burst 허용. 실거래소 rate limit은 burst 불허 케이스도 있으니 확인 필요.
+- **PnL Attribution**: `market_move + slippage + fees = realized_pnl` 분해가 전략 개선 진단에 핵심. 데이터가 실제 fill price와 expected price의 차이를 포함해야 slippage가 정확함.
+- **Latency SLO**: p50/p95/p99 percentile 추적 → paper mode에서는 latency 거의 0이라 live 전환 시 다시 캘리브레이션 필요.
+
+### Gotchas
+- `FatFingerGuard.check()` 리턴이 `(bool, str)` 튜플. bool만 체크하면 reason 정보 손실.
+- `OrderManager`가 `max_order_size` config로 자동 clamping함 — 운영 전 이 값 확인 필수.
+
+---
+
+## Track D — Model Lifecycle (Weeks 67-68)
+
+### 배운 것
+- **DriftDetector**: ADWIN/PageHinkley가 feature별 drift를 returns drift보다 먼저 감지. early warning 효과.
+- **Regime detection**: live wire 연결 자체보다 "regime 변경 시 무엇을 할 것인가" 정책 결정이 더 중요. 현재 log만 — 충분.
+- **ModelRegistry**: MLflow 없이 파일 기반으로도 버전 관리 + rollback 가능. 원자적 write(tmp → rename)이 핵심.
+- **Shadow agent**: main과 동일 obs로 새 모델을 "dry run" — 운영 영향 없이 성능 비교. audit log에 남아서 분석 가능.
+
+### Gotchas
+- `shadow_agent`가 raise하면 main loop이 멈추면 안 된다 → `try/except` 필수.
+- `AuditLogger.log_model_decision(extra=...)` 필드 추가 시 hash chain에 영향 → schema 변경 금지.
+- Week 67 구현 누락 (model_registry.py) → Week 68에서 보완. plan 체크리스트 실행 중 미완료 항목 발생 시 다음 week으로 이월하지 말고 해당 week에 처리할 것.
+
+---
+
+## Phase 7 후보 (우선순위 순)
+
+1. **UnifiedRiskManager ↔ RiskManagerBase 완전 통합**: `PaperTrader._check_risk()`가 `check_max_drawdown`을 호출하는데 `UnifiedRiskManager`에 없음. 둘을 연결해야 risk 경로가 통일됨.
+2. **실거래소 연동**: CCXT live mode + API key (cloud secret manager). 현재 simulation mode만 검증됨.
+3. **Multi-asset live**: `MultiAgentManager` phase 6에서도 wire 안 됨. single-asset 먼저 실거래 검증 후.
+4. **MLflow experiment tracking**: model_registry.py를 MLflow artifact store와 연결.
+5. **Shadow agent dashboard**: 현재 audit log에만 기록. Grafana/Streamlit에서 실시간 비교.
+6. **Rollback 핫스왑**: restart 없이 running PaperTrader의 agent 교체.
+7. **Kubernetes / 컨테이너화**: 현재 docker-compose. k8s로 확장 시 stateful set 고려.
+8. **Compliance / tax reporting**: 거래 기록 → 세금 신고 자동화.
+
+---
+
+## Phase 6 완료 조건 최종 체크
+
+- [x] 실거래 시나리오 drill 3종 통과 (Week 59)
+- [x] audit log 체인 검증 통과 (Week 57, smoke 확인)
+- [x] 평문 secret 0건 (Week 58)
+- [x] UnifiedRiskManager로 통합, parity 테스트 통과 (Week 60)
+- [x] Config 23 → ≤10 (Week 63: 5 base + env overrides)
+- [x] Fat-finger / circuit breaker / rate limiter live 경로 연결 (Week 64)
+- [x] PnL attribution이 계산됨 (Week 66, 정확성 테스트 통과)
+- [x] Shadow agent 동작 검증 (Week 68, 7개 테스트)
+- [x] 전체 회귀 0 fail (1727 passed)
+
+**Phase 6 완료.**

--- a/docs/phase6/week68.md
+++ b/docs/phase6/week68.md
@@ -1,0 +1,77 @@
+# Week 68: Rollback / Shadow Deploy & Final Validation (S61-S65)
+
+**날짜**: 2026-04-12  
+**브랜치**: `claude/elated-ptolemy`  
+**목표**: Phase 6 마지막 week — shadow agent, model rollback, 전체 smoke, 최종 회귀
+
+---
+
+## What (무엇을 했나)
+
+### S61 — Shadow Agent (PaperTrader)
+- `PaperTrader.__init__`에 `shadow_agent=None` 파라미터 추가
+- 매 step 관찰 후 shadow agent의 `predict()` 호출 → **주문 없음**
+- 결정 비교 (`main_action` vs `shadow_action`) → `AuditLogger.log_model_decision(source="shadow")`
+- `_run_shadow_agent()` 예외 처리: shadow 실패해도 main loop 계속
+- `AuditLogger.log_model_decision`에 `extra: dict` 파라미터 추가 (하위호환)
+- 테스트: `tests/deployment/test_shadow_mode.py` (7개)
+
+### S62 — Model Registry + Rollback
+- `training/registry/model_registry.py` 생성 (Week 67에서 누락)
+  - 파일 기반 로컬 레지스트리 (MLflow 불필요)
+  - `register()`, `set_active()`, `get_active()`, `get_version()`, `list_versions()`, `rollback()`, `delete_version()`
+  - 원자적 index 쓰기 (`registry.json.tmp` → rename)
+  - thread-safe (`threading.Lock`)
+- `scripts/rollback_model.py` CLI
+  - `<version>` positional arg, `--list`, `--show`, `--active-model-path`, `--registry-dir`
+  - 성공 시 exit 0, 버전 없으면 exit 1
+- 테스트: `tests/training/test_model_registry.py` (20개)
+
+### S63 — Phase 6 Smoke Test
+- `scripts/phase6_smoke.py` — 12개 섹션, 33개 체크
+  - Track A: StateStore (save/load/clear), AuditLogger (chain verify)
+  - Track B: UnifiedRiskManager (position limit), StaticDataSource (window/staleness), config loader
+  - Track C: FatFingerGuard, VolatilityCircuitBreaker, RateLimiter, PnLAttributor
+  - Track D: Shadow agent audit, ModelRegistry + rollback CLI
+  - Full E2E: 모든 컴포넌트 동시 실행 (PaperTrader + StateStore + AuditLogger + OrderManager + shadow)
+- 33/33 PASS, exit 0
+
+### S64 — 최종 회귀
+- **1727 passed, 19 skipped, 0 failed** (baseline 1386 + Phase 6 신규 341)
+- pytest.ini ignore 목록 변동 없음
+
+### S65 — 문서
+- 이 문서 + `docs/phase6/RETRO.md`
+
+---
+
+## Why (왜 이렇게 했나)
+
+**Shadow agent**: 실거래 전 새 모델을 "live trial" 없이 검증하는 가장 안전한 방법. 기존 main agent의 주문에 전혀 영향 없이 결정 비교 가능. audit log에 남기면 사후 분석도 된다.
+
+**ModelRegistry 파일 기반**: MLflow 없어도 동작해야 함 (부록 B: MLflow 도입은 Phase 7). `registry.json.tmp → rename` 패턴으로 partial write 방지.
+
+**Rollback CLI**: PaperTrader restart 전제 — 운영 중 핫스왑 지원 안 하는 것이 맞다. registry pointer만 바꾸고 별도 `--active-model-path` 옵션으로 파일도 교체 가능.
+
+**Smoke test 설계**: 각 컴포넌트가 실제로 `동작하는지`를 별도 단위로 검증 (unit test) + 마지막에 전부 묶어서 통합(E2E). 하나라도 실패하면 exit 1.
+
+---
+
+## Gotchas (주의사항)
+
+1. **UnifiedRiskManager ↔ PaperTrader**: `PaperTrader._check_risk()`는 `risk_manager.check_max_drawdown()`을 호출하지만 `UnifiedRiskManager`엔 이 메서드가 없다. 둘은 아직 완전히 연결 안 됨 — `check_drawdown`이 있고 signature도 다름. Phase 7에서 `RiskManagerBase`를 `UnifiedRiskManager`로 교체 시 주의.
+
+2. **`AuditLogger.log_model_decision` extra 필드**: hash chain은 `payload` 전체를 포함하므로 `extra` 키가 바뀌면 chain이 이어지지 않는다. schema 바꾸지 말 것.
+
+3. **VolatilityCircuitBreaker threshold**: 실제 운영 설정에서 `vol_threshold`를 너무 낮게 잡으면 정상 시장에서도 trip 발생. 초기 calibration 필요.
+
+4. **shadow_agent가 main_agent와 동일한 obs를 받음**: obs는 같지만 shadow가 main과 다른 내부 state를 갖는 SB3 모델이라면 predict() 결과가 달라질 수 있다. 의도된 동작.
+
+---
+
+## 미완료 / Phase 7 후보
+
+- UnifiedRiskManager ↔ PaperTrader 완전 연결 (check_max_drawdown 구현 or PaperTrader 수정)
+- Shadow agent live dashboard (현재 audit log에만 기록)
+- Model registry → MLflow 연동 (Phase 7)
+- Rollback 중 running PaperTrader 핫스왑 (현재 restart 필요)

--- a/scripts/phase6_smoke.py
+++ b/scripts/phase6_smoke.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python
+"""
+Phase 6 End-to-End Smoke Test (Week 68, S63).
+
+Exercises all Track A/B/C/D features in a single run:
+  Track A — StateStore (persistence), AuditLogger (audit)
+  Track B — UnifiedRiskManager, DataSource interface, config loader
+  Track C — Fat-finger guard, volatility circuit breaker, rate limiter
+  Track D — PnL attribution, shadow agent, model registry
+
+Exit 0 on success, non-zero on any failure.
+
+Usage::
+
+    python scripts/phase6_smoke.py
+    python scripts/phase6_smoke.py --verbose
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Tuple
+
+import numpy as np
+
+# --------------------------------------------------------------------------
+# Repo root on path
+# --------------------------------------------------------------------------
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT))
+
+# --------------------------------------------------------------------------
+# Logging
+# --------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.WARNING,
+    format="%(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("phase6_smoke")
+
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+
+_results: list[Tuple[str, bool, str]] = []
+
+
+def _check(name: str, ok: bool, detail: str = "") -> None:
+    status = PASS if ok else FAIL
+    print(f"  [{status}] {name}" + (f" — {detail}" if detail else ""))
+    _results.append((name, ok, detail))
+    if not ok:
+        logger.warning("SMOKE FAIL: %s %s", name, detail)
+
+
+def _section(title: str) -> None:
+    print(f"\n{'─' * 60}")
+    print(f"  {title}")
+    print(f"{'─' * 60}")
+
+
+# --------------------------------------------------------------------------
+# Helpers / shared fixtures
+# --------------------------------------------------------------------------
+
+class _DummyAgent:
+    """Always returns the same scalar action."""
+    def __init__(self, action: float = 0.3):
+        self._action = action
+
+    def predict(self, obs, deterministic=True):
+        return np.array([self._action]), None
+
+
+def _prices(n: int = 80) -> list:
+    rng = np.random.default_rng(7)
+    return (100.0 + np.cumsum(rng.normal(0, 0.5, n))).tolist()
+
+
+def _base_config(
+    db_path: str = ":memory:",
+    log_path: str | None = None,
+) -> dict:
+    cfg: dict[str, Any] = {
+        "paper_trading": {
+            "symbol": "BTC/USDT",
+            "initial_balance": 10_000.0,
+            "trading_fee": 0.001,
+            "max_position_size": 1.0,
+            "max_drawdown_threshold": 0.99,
+            "window_size": 5,
+        },
+        "monitoring": {},
+        "persistence": {
+            "enabled": True,
+            "db_path": db_path,
+            "checkpoint_every_n_steps": 1,
+        },
+    }
+    return cfg
+
+
+# --------------------------------------------------------------------------
+# Track A — Ops Readiness
+# --------------------------------------------------------------------------
+
+def smoke_state_store(tmp_dir: str) -> None:
+    _section("Track A1: StateStore (persistence)")
+    from deployment.persistence.state_store import StateStore
+
+    db = os.path.join(tmp_dir, "smoke_state.db")
+    store = StateStore(db)
+    snap = {
+        "symbol": "BTC/USDT",
+        "position": 0.1,
+        "entry_price": 100.0,
+        "cash": 9_000.0,
+        "current_price": 101.0,
+        "peak_value": 10_100.0,
+        "equity": 9_100.1,
+        "step": 42,
+        "shutdown_triggered": False,
+        "shutdown_reason": "",
+        "portfolio_history": [10_000.0, 10_050.0, 10_100.0],
+        "trades": [],
+        "orders": [],
+    }
+    store.save_snapshot(snap)
+    loaded = store.load_latest()
+    _check("StateStore.save_snapshot + load_latest", loaded is not None)
+    _check("StateStore.step restored", loaded is not None and loaded.get("step") == 42)
+    store.clear()
+    _check("StateStore.clear", store.load_latest() is None)
+
+
+def smoke_audit_logger(tmp_dir: str) -> None:
+    _section("Track A2: AuditLogger (immutable audit)")
+    from deployment.audit.audit_logger import AuditLogger
+
+    log_path = os.path.join(tmp_dir, "smoke_audit.jsonl")
+    al = AuditLogger(log_path=log_path, fsync=False)
+    for i in range(20):
+        al.log_risk_event({"type": "test", "i": i})
+    al.log_model_decision(action=0.3, obs_hash="abc123")
+    al.close()
+
+    records = []
+    with open(log_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+
+    _check("AuditLogger records written", len(records) == 21)
+
+    verify = _ROOT / "scripts" / "verify_audit_log.py"
+    res = subprocess.run(
+        [sys.executable, str(verify), log_path],
+        capture_output=True, text=True,
+    )
+    _check("AuditLogger chain valid (verify script exit 0)", res.returncode == 0, res.stderr.strip())
+
+
+# --------------------------------------------------------------------------
+# Track B — Architecture Consolidation
+# --------------------------------------------------------------------------
+
+def smoke_unified_risk_manager() -> None:
+    _section("Track B1: UnifiedRiskManager")
+    from risk_management.unified_risk_manager import UnifiedRiskManager
+
+    urm = UnifiedRiskManager(mode="backtest", var_method="parametric")
+    # Within limit: 500 / 10000 = 5% < 50% max → True
+    within = urm.check_position_limit(
+        position_value=500.0, portfolio_value=10_000.0, max_position_fraction=0.5
+    )
+    # Exceeds limit: 8000 / 10000 = 80% > 50% max → False
+    exceeds = urm.check_position_limit(
+        position_value=8_000.0, portfolio_value=10_000.0, max_position_fraction=0.5
+    )
+    _check("check_position_limit: within limit returns True", within)
+    _check("check_position_limit: exceeds limit returns False", not exceeds)
+
+
+def smoke_data_source() -> None:
+    _section("Track B2: DataSource abstraction")
+    import pandas as pd
+    from data.sources.base import StaticDataSource
+
+    df = pd.DataFrame({
+        "$close": _prices(50),
+        "$volume": [1000.0] * 50,
+    })
+    ds = StaticDataSource(df)
+    _check("StaticDataSource.__len__", len(ds) == 50)
+    _check("StaticDataSource.is_live = False", not ds.is_live())
+    _check("StaticDataSource.is_stale = False", not ds.is_stale(60))
+    window = ds.get_window(0, 10)
+    _check("StaticDataSource.get_window", len(window) == 10)
+
+
+def smoke_config_loader() -> None:
+    _section("Track B3: Config loader")
+    from config.loader import load
+    try:
+        cfg = load()
+        _check("config.loader.load() returns dict", isinstance(cfg, dict))
+        _check("config.loader.load() has content", len(cfg) > 0)
+    except Exception as e:
+        _check("config.loader.load() returns dict", False, str(e))
+
+
+# --------------------------------------------------------------------------
+# Track C — Production Safety
+# --------------------------------------------------------------------------
+
+def smoke_fat_finger() -> None:
+    _section("Track C1: Fat-finger guard")
+    from deployment.execution.fat_finger_guard import FatFingerGuard
+
+    guard = FatFingerGuard(hard_cap=10.0, size_multiplier_limit=5.0, lookback=10)
+    ok, _ = guard.check(amount=1.0)
+    _check("Fat-finger: small order passes", ok)
+    blocked, _ = guard.check(amount=11.0)
+    _check("Fat-finger: hard-cap exceeded blocked", not blocked)
+
+    # Seed history, then spike
+    for _ in range(10):
+        guard.record_fill(1.0)
+    spiked, _ = guard.check(amount=8.0)
+    _check("Fat-finger: spike order blocked", not spiked)
+
+
+def smoke_circuit_breaker() -> None:
+    _section("Track C2: Volatility circuit breaker")
+    from deployment.execution.circuit_breaker import VolatilityCircuitBreaker
+
+    # High threshold → stable prices should NOT trip
+    cb_stable = VolatilityCircuitBreaker(vol_threshold=0.5, window=5, cooldown=0.0)
+    for p in [100.0, 100.1, 100.2, 100.1, 100.0]:
+        cb_stable.update(p)
+    stable_tripped = cb_stable.is_tripped()
+    _check("Circuit breaker: stable prices not tripped (high threshold)", not stable_tripped)
+
+    # Very low threshold → volatile prices trip the breaker
+    cb_vol = VolatilityCircuitBreaker(vol_threshold=0.001, window=5, cooldown=0.0)
+    for p in [100.0, 110.0, 80.0, 120.0, 70.0]:
+        cb_vol.update(p)
+    volatile_tripped = cb_vol.is_tripped()
+    _check("Circuit breaker: volatile prices trip breaker", volatile_tripped)
+
+
+def smoke_rate_limiter() -> None:
+    _section("Track C3: Rate limiter")
+    from deployment.execution.rate_limiter import RateLimiter
+
+    rl = RateLimiter(max_calls=5, period=1.0)
+    t0 = time.monotonic()
+    for _ in range(5):
+        rl.acquire()
+    elapsed = time.monotonic() - t0
+    _check("RateLimiter: 5 calls within 1s", elapsed < 1.0)
+
+
+# --------------------------------------------------------------------------
+# Track C: PnL attribution (from Week 66)
+# --------------------------------------------------------------------------
+
+def smoke_pnl_attribution() -> None:
+    _section("Track C/D: PnL attribution")
+    from deployment.paper_trader import PaperTrader, Trade
+    from deployment.analysis.pnl_attribution import PnLAttributor
+    from datetime import datetime
+
+    trades = [
+        Trade(timestamp=datetime.utcnow(), side="buy", price=100.0, quantity=1.0, fee=0.1, pnl=0.0),
+        Trade(timestamp=datetime.utcnow(), side="sell", price=105.0, quantity=1.0, fee=0.1, pnl=4.8),
+    ]
+    attr = PnLAttributor()
+    attributions = attr.attribute(trades, slippage_records=[0.001])
+    summary = attr.summarise(attributions)
+    fields = attr.to_exporter_fields(summary)
+
+    _check("PnLAttributor.attribute returns list", len(attributions) > 0)
+    _check("PnLAttributor.summarise.total_net_pnl positive (buy low sell high)",
+           summary.total_net_pnl > 0)
+    _check("to_exporter_fields returns dict", isinstance(fields, dict))
+
+
+# --------------------------------------------------------------------------
+# Track D — Shadow agent + model registry
+# --------------------------------------------------------------------------
+
+def smoke_shadow_agent(tmp_dir: str) -> None:
+    _section("Track D1: Shadow agent")
+    from deployment.paper_trader import PaperTrader
+    from deployment.audit.audit_logger import AuditLogger
+
+    log_path = os.path.join(tmp_dir, "shadow_smoke.jsonl")
+    al = AuditLogger(log_path=log_path, fsync=False)
+
+    main_agent = _DummyAgent(action=0.4)
+    shadow_agent = _DummyAgent(action=-0.3)
+
+    trader = PaperTrader(
+        agent=main_agent,
+        config=_base_config(),
+        simulation_mode=True,
+        shadow_agent=shadow_agent,
+        audit_logger=al,
+    )
+    report = trader.run(price_stream=iter(_prices(40)))
+    al.close()
+
+    # Shadow decisions in audit log
+    records = []
+    with open(log_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+
+    shadow_recs = [
+        r for r in records
+        if r["type"] == "model_decision" and r["payload"].get("source") == "shadow"
+    ]
+    _check("Shadow agent: decisions logged", len(shadow_recs) > 0)
+    _check("Shadow agent: does not affect trade count",
+           report["num_trades"] >= 0)  # just verify run completes cleanly
+
+
+def smoke_model_registry(tmp_dir: str) -> None:
+    _section("Track D2: Model registry + rollback")
+    from training.registry.model_registry import ModelRegistry
+
+    reg_dir = os.path.join(tmp_dir, "smoke_registry")
+    reg = ModelRegistry(registry_dir=reg_dir)
+
+    # Create a fake model file
+    fake_model = os.path.join(tmp_dir, "model_v1.zip")
+    Path(fake_model).write_bytes(b"FAKE_WEIGHTS")
+
+    ver = reg.register(
+        model_path=fake_model,
+        metrics={"sharpe": 1.2, "max_dd": 0.07},
+        config={"algo": "PPO"},
+        tag="smoke-test",
+    )
+    _check("Registry: register returns version", ver == 1)
+    _check("Registry: get_version", reg.get_version(ver)["tag"] == "smoke-test")
+
+    reg.set_active(ver)
+    _check("Registry: set_active + get_active", reg.get_active()["version"] == ver)
+
+    # rollback via CLI
+    result = subprocess.run(
+        [sys.executable, str(_ROOT / "scripts" / "rollback_model.py"),
+         str(ver), "--registry-dir", reg_dir],
+        capture_output=True, text=True,
+    )
+    _check("rollback_model.py CLI exit 0", result.returncode == 0, result.stderr.strip())
+    _check("rollback_model.py CLI output mentions version",
+           f"version {ver}" in result.stdout)
+
+
+# --------------------------------------------------------------------------
+# Full PaperTrader end-to-end (all Phase 6 features combined)
+# --------------------------------------------------------------------------
+
+def smoke_full_papertrader(tmp_dir: str) -> None:
+    _section("Full E2E: PaperTrader with all Phase 6 features")
+    from deployment.paper_trader import PaperTrader
+    from deployment.audit.audit_logger import AuditLogger
+    from deployment.persistence.state_store import StateStore
+    from deployment.execution.order_manager import OrderManager
+    from deployment.execution.fat_finger_guard import FatFingerGuard
+    from deployment.execution.circuit_breaker import VolatilityCircuitBreaker
+
+    db_path = os.path.join(tmp_dir, "e2e_state.db")
+    log_path = os.path.join(tmp_dir, "e2e_audit.jsonl")
+
+    state_store = StateStore(db_path)
+    audit_logger = AuditLogger(log_path=log_path, fsync=False)
+
+    fat_finger = FatFingerGuard(hard_cap=1e6, size_multiplier_limit=20.0, lookback=50)
+    circuit_breaker = VolatilityCircuitBreaker(vol_threshold=0.5, window=5, cooldown=0.0)
+
+    order_manager = OrderManager(
+        exchange_config={},
+        paper_mode=True,
+        fat_finger_guard=fat_finger,
+        circuit_breaker=circuit_breaker,
+        audit_logger=audit_logger,
+    )
+
+    main_agent = _DummyAgent(action=0.35)
+    shadow_agent = _DummyAgent(action=-0.15)
+
+    config = _base_config(db_path=db_path)
+    trader = PaperTrader(
+        agent=main_agent,
+        config=config,
+        simulation_mode=True,
+        state_store=state_store,
+        audit_logger=audit_logger,
+        order_manager=order_manager,
+        # risk_manager uses PaperTrader's built-in drawdown check; UnifiedRiskManager
+        # is verified separately in smoke_unified_risk_manager().
+        shadow_agent=shadow_agent,
+    )
+
+    report = trader.run(price_stream=iter(_prices(60)))
+    audit_logger.close()
+
+    _check("E2E: PaperTrader completes run", report["steps"] > 0)
+    _check("E2E: StateStore has checkpoint", state_store.load_latest() is not None)
+
+    records = []
+    with open(log_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    _check("E2E: AuditLogger has records", len(records) > 0)
+
+    verify = _ROOT / "scripts" / "verify_audit_log.py"
+    res = subprocess.run(
+        [sys.executable, str(verify), log_path],
+        capture_output=True, text=True,
+    )
+    _check("E2E: Audit chain valid", res.returncode == 0, res.stderr.strip())
+
+
+# --------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Phase 6 smoke test")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    print("=" * 60)
+    print("  Phase 6 Production Readiness — Smoke Test (Week 68 S63)")
+    print("=" * 60)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        try:
+            smoke_state_store(tmp_dir)
+        except Exception as e:
+            _check("Track A1: StateStore", False, str(e))
+
+        try:
+            smoke_audit_logger(tmp_dir)
+        except Exception as e:
+            _check("Track A2: AuditLogger", False, str(e))
+
+        try:
+            smoke_unified_risk_manager()
+        except Exception as e:
+            _check("Track B1: UnifiedRiskManager", False, str(e))
+
+        try:
+            smoke_data_source()
+        except Exception as e:
+            _check("Track B2: DataSource", False, str(e))
+
+        try:
+            smoke_config_loader()
+        except Exception as e:
+            _check("Track B3: Config loader", False, str(e))
+
+        try:
+            smoke_fat_finger()
+        except Exception as e:
+            _check("Track C1: Fat-finger", False, str(e))
+
+        try:
+            smoke_circuit_breaker()
+        except Exception as e:
+            _check("Track C2: Circuit breaker", False, str(e))
+
+        try:
+            smoke_rate_limiter()
+        except Exception as e:
+            _check("Track C3: Rate limiter", False, str(e))
+
+        try:
+            smoke_pnl_attribution()
+        except Exception as e:
+            _check("Track C/D: PnL attribution", False, str(e))
+
+        try:
+            smoke_shadow_agent(tmp_dir)
+        except Exception as e:
+            _check("Track D1: Shadow agent", False, str(e))
+
+        try:
+            smoke_model_registry(tmp_dir)
+        except Exception as e:
+            _check("Track D2: Model registry", False, str(e))
+
+        try:
+            smoke_full_papertrader(tmp_dir)
+        except Exception as e:
+            _check("Full E2E: PaperTrader", False, str(e))
+
+    # ---------- Summary ----------
+    total = len(_results)
+    passed = sum(1 for _, ok, _ in _results if ok)
+    failed = total - passed
+
+    print(f"\n{'=' * 60}")
+    print(f"  Results: {passed}/{total} passed", end="")
+    if failed:
+        print(f"  ← {failed} FAILED")
+    else:
+        print("  ✓ all passed")
+    print("=" * 60)
+
+    if failed:
+        print("\nFailed checks:")
+        for name, ok, detail in _results:
+            if not ok:
+                print(f"  • {name}: {detail}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rollback_model.py
+++ b/scripts/rollback_model.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+"""
+Week 68 (S62): Model rollback command.
+
+Usage:
+    python scripts/rollback_model.py <version> [options]
+
+Examples:
+    # List all registered versions
+    python scripts/rollback_model.py --list
+
+    # Roll back to version 3 (updates active pointer only)
+    python scripts/rollback_model.py 3
+
+    # Roll back to version 3 and copy checkpoint to a specific path
+    python scripts/rollback_model.py 3 --active-model-path models/active/model.zip
+
+    # Use a custom registry directory
+    python scripts/rollback_model.py 3 --registry-dir /path/to/registry
+
+Prerequisite: PaperTrader must be restarted after rollback to pick up the new model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Make sure repo root is on sys.path when invoked directly
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from training.registry.model_registry import ModelRegistry, _DEFAULT_REGISTRY_DIR
+
+
+def _list_versions(registry: ModelRegistry) -> None:
+    versions = registry.list_versions()
+    if not versions:
+        print("No versions registered.")
+        return
+    print(f"{'Ver':>4}  {'Registered At':<27}  {'Active':>6}  Tag")
+    print("-" * 65)
+    for v in versions:
+        active_marker = "  <--" if v["is_active"] else ""
+        print(
+            f"{v['version']:>4}  {v['registered_at']:<27}  "
+            f"{str(v['is_active']):>6}  {v['tag']}{active_marker}"
+        )
+
+
+def _show_version(registry: ModelRegistry, version: int) -> None:
+    try:
+        meta = registry.get_version(version)
+    except (KeyError, FileNotFoundError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    print(json.dumps(meta, indent=2))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Roll back the active model to a previously registered version.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "version",
+        nargs="?",
+        type=int,
+        help="Target version number to roll back to.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List all registered versions and exit.",
+    )
+    parser.add_argument(
+        "--show",
+        type=int,
+        metavar="VERSION",
+        help="Print metadata for a specific version and exit.",
+    )
+    parser.add_argument(
+        "--active-model-path",
+        metavar="PATH",
+        default=None,
+        help=(
+            "If given, copy the rolled-back checkpoint to this path so a "
+            "restarted PaperTrader picks it up automatically."
+        ),
+    )
+    parser.add_argument(
+        "--registry-dir",
+        metavar="DIR",
+        default=_DEFAULT_REGISTRY_DIR,
+        help=f"Registry root directory (default: {_DEFAULT_REGISTRY_DIR}).",
+    )
+
+    args = parser.parse_args(argv)
+    registry = ModelRegistry(registry_dir=args.registry_dir)
+
+    if args.list:
+        _list_versions(registry)
+        return 0
+
+    if args.show is not None:
+        _show_version(registry, args.show)
+        return 0
+
+    if args.version is None:
+        parser.error("Provide a version number or use --list / --show.")
+
+    try:
+        stored_path = registry.rollback(
+            target_version=args.version,
+            active_model_path=args.active_model_path,
+        )
+    except (KeyError, FileNotFoundError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Rolled back to version {args.version}.")
+    print(f"Checkpoint path: {stored_path}")
+    if args.active_model_path:
+        print(f"Copied to: {args.active_model_path}")
+    print("\nRestart PaperTrader to apply the rollback.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/deployment/test_shadow_mode.py
+++ b/tests/deployment/test_shadow_mode.py
@@ -1,0 +1,258 @@
+"""
+Week 68 (S61): Shadow mode tests for PaperTrader.
+
+Shadow agent observes the same state as the main agent but never submits orders.
+Its decisions are recorded to the audit log for post-hoc comparison only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from typing import Any, Tuple
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from deployment.paper_trader import PaperTrader
+from deployment.audit.audit_logger import AuditLogger
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _DummyAgent:
+    """Deterministic agent that always returns the same scalar action."""
+
+    def __init__(self, action: float = 0.5) -> None:
+        self._action = action
+        self.call_count: int = 0
+
+    def predict(self, obs, deterministic: bool = True) -> Tuple[np.ndarray, Any]:
+        self.call_count += 1
+        return np.array([self._action]), None
+
+
+def _build_config() -> dict:
+    return {
+        "paper_trading": {
+            "symbol": "BTC/USDT",
+            "initial_balance": 10_000.0,
+            "trading_fee": 0.001,
+            "max_position_size": 1.0,
+            "max_drawdown_threshold": 0.99,
+            "window_size": 5,
+        },
+        "monitoring": {},
+    }
+
+
+def _price_stream(n: int = 30) -> list:
+    rng = np.random.default_rng(42)
+    prices = 100.0 + np.cumsum(rng.normal(0, 0.5, n))
+    return prices.tolist()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestShadowModeBasic:
+    """Shadow agent is called every step but never submits orders."""
+
+    def test_shadow_agent_called_each_step(self):
+        main_agent = _DummyAgent(action=0.3)
+        shadow_agent = _DummyAgent(action=-0.2)
+        config = _build_config()
+        prices = _price_stream(30)
+
+        trader = PaperTrader(
+            agent=main_agent,
+            config=config,
+            simulation_mode=True,
+            shadow_agent=shadow_agent,
+        )
+        trader.run(price_stream=iter(prices))
+
+        # Shadow agent should have been called at least once (after window fills)
+        assert shadow_agent.call_count > 0
+
+    def test_shadow_agent_does_not_affect_trades(self):
+        """Running with vs without a shadow agent produces identical main trades."""
+        main_prices = _price_stream(40)
+
+        def _run(with_shadow: bool) -> dict:
+            np.random.seed(0)  # ensure identical rng state
+            main = _DummyAgent(action=0.4)
+            shadow = _DummyAgent(action=-0.9) if with_shadow else None
+            t = PaperTrader(
+                agent=main,
+                config=_build_config(),
+                simulation_mode=True,
+                shadow_agent=shadow,
+            )
+            return t.run(price_stream=iter(list(main_prices)))
+
+        report_no_shadow = _run(False)
+        report_with_shadow = _run(True)
+
+        assert report_no_shadow["num_trades"] == report_with_shadow["num_trades"]
+        assert abs(report_no_shadow["final_portfolio_value"] - report_with_shadow["final_portfolio_value"]) < 1e-6
+
+    def test_no_shadow_agent_no_extra_orders(self):
+        """Without a shadow agent, order_manager is only called by main agent logic."""
+        main_agent = _DummyAgent(action=0.5)
+        order_manager = MagicMock()
+        order_manager.submit_order.return_value = "ord-1"
+        order_manager.check_order.return_value = None
+        order_manager.compute_latency_percentiles.return_value = {"p50": 0, "p95": 0, "p99": 0}
+
+        config = _build_config()
+        trader = PaperTrader(
+            agent=main_agent,
+            config=config,
+            simulation_mode=True,
+            order_manager=order_manager,
+            shadow_agent=None,
+        )
+        trader.run(price_stream=iter(_price_stream(20)))
+        # Any calls come only from main agent
+        call_count_no_shadow = order_manager.submit_order.call_count
+
+        # Now with a shadow agent — order_manager calls must NOT increase
+        order_manager2 = MagicMock()
+        order_manager2.submit_order.return_value = "ord-2"
+        order_manager2.check_order.return_value = None
+        order_manager2.compute_latency_percentiles.return_value = {"p50": 0, "p95": 0, "p99": 0}
+
+        shadow = _DummyAgent(action=-0.9)
+        trader2 = PaperTrader(
+            agent=_DummyAgent(action=0.5),
+            config=config,
+            simulation_mode=True,
+            order_manager=order_manager2,
+            shadow_agent=shadow,
+        )
+        trader2.run(price_stream=iter(_price_stream(20)))
+        call_count_with_shadow = order_manager2.submit_order.call_count
+
+        assert call_count_with_shadow == call_count_no_shadow
+
+
+class TestShadowModeAuditLog:
+    """Shadow decisions must appear in audit log, tagged as source='shadow'."""
+
+    def test_shadow_decisions_logged_to_audit(self, tmp_path):
+        log_file = str(tmp_path / "audit.jsonl")
+        audit = AuditLogger(log_path=log_file, fsync=False)
+
+        main_agent = _DummyAgent(action=0.3)
+        shadow_agent = _DummyAgent(action=-0.7)
+        config = _build_config()
+
+        trader = PaperTrader(
+            agent=main_agent,
+            config=config,
+            simulation_mode=True,
+            shadow_agent=shadow_agent,
+            audit_logger=audit,
+        )
+        trader.run(price_stream=iter(_price_stream(30)))
+        audit.close()
+
+        # Parse audit log
+        records = []
+        with open(log_file, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    records.append(json.loads(line))
+
+        shadow_records = [
+            r for r in records
+            if r["type"] == "model_decision"
+            and r["payload"].get("source") == "shadow"
+        ]
+        assert len(shadow_records) > 0, "No shadow decisions found in audit log"
+
+    def test_shadow_record_contains_comparison_fields(self, tmp_path):
+        log_file = str(tmp_path / "audit.jsonl")
+        audit = AuditLogger(log_path=log_file, fsync=False)
+
+        trader = PaperTrader(
+            agent=_DummyAgent(action=0.3),
+            config=_build_config(),
+            simulation_mode=True,
+            shadow_agent=_DummyAgent(action=-0.7),
+            audit_logger=audit,
+        )
+        trader.run(price_stream=iter(_price_stream(20)))
+        audit.close()
+
+        records = []
+        with open(log_file, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    records.append(json.loads(line))
+
+        shadow_recs = [
+            r for r in records
+            if r["type"] == "model_decision" and r["payload"].get("source") == "shadow"
+        ]
+        assert len(shadow_recs) > 0
+        rec = shadow_recs[0]["payload"]
+        # Must contain comparison fields
+        assert "main_action" in rec
+        assert "shadow_action" in rec
+        assert "step" in rec
+        assert "obs_hash" in rec
+
+    def test_shadow_failure_does_not_crash_trader(self):
+        """If shadow agent raises, main trading loop must continue."""
+        main_agent = _DummyAgent(action=0.3)
+
+        class _BrokenAgent:
+            def predict(self, obs, deterministic=True):
+                raise RuntimeError("shadow broken")
+
+        trader = PaperTrader(
+            agent=main_agent,
+            config=_build_config(),
+            simulation_mode=True,
+            shadow_agent=_BrokenAgent(),
+        )
+        report = trader.run(price_stream=iter(_price_stream(25)))
+        # Main agent should still have traded normally
+        assert report["steps"] > 0
+
+    def test_shadow_audit_log_chain_valid(self, tmp_path):
+        """Audit log including shadow entries must pass hash-chain verification."""
+        import subprocess
+        import sys
+
+        log_file = str(tmp_path / "audit.jsonl")
+        audit = AuditLogger(log_path=log_file, fsync=False)
+
+        trader = PaperTrader(
+            agent=_DummyAgent(action=0.4),
+            config=_build_config(),
+            simulation_mode=True,
+            shadow_agent=_DummyAgent(action=-0.2),
+            audit_logger=audit,
+        )
+        trader.run(price_stream=iter(_price_stream(30)))
+        audit.close()
+
+        verify_script = os.path.join(
+            os.path.dirname(__file__), "..", "..", "scripts", "verify_audit_log.py"
+        )
+        result = subprocess.run(
+            [sys.executable, verify_script, log_file],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"Audit chain broken:\n{result.stdout}\n{result.stderr}"

--- a/tests/training/test_model_registry.py
+++ b/tests/training/test_model_registry.py
@@ -1,0 +1,166 @@
+"""Week 67/68 (S59, S62): ModelRegistry unit tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from training.registry.model_registry import ModelRegistry
+
+
+@pytest.fixture
+def reg(tmp_path):
+    return ModelRegistry(registry_dir=str(tmp_path / "registry"))
+
+
+@pytest.fixture
+def dummy_model(tmp_path):
+    """Create a dummy .zip checkpoint file."""
+    p = tmp_path / "model.zip"
+    p.write_bytes(b"FAKE_MODEL_WEIGHTS")
+    return str(p)
+
+
+class TestModelRegistryBasic:
+    def test_register_returns_version_1_first(self, reg, dummy_model):
+        ver = reg.register(model_path=dummy_model, metrics={"sharpe": 1.0})
+        assert ver == 1
+
+    def test_register_increments_version(self, reg, dummy_model):
+        v1 = reg.register(model_path=dummy_model)
+        v2 = reg.register(model_path=dummy_model)
+        assert v2 == v1 + 1
+
+    def test_get_version_returns_meta(self, reg, dummy_model):
+        ver = reg.register(
+            model_path=dummy_model,
+            metrics={"sharpe": 1.5, "max_dd": 0.07},
+            config={"algo": "PPO"},
+            tag="test-run",
+        )
+        meta = reg.get_version(ver)
+        assert meta["version"] == ver
+        assert meta["metrics"]["sharpe"] == 1.5
+        assert meta["config"]["algo"] == "PPO"
+        assert meta["tag"] == "test-run"
+
+    def test_get_version_unknown_raises(self, reg):
+        with pytest.raises(KeyError):
+            reg.get_version(999)
+
+    def test_list_versions_empty(self, reg):
+        assert reg.list_versions() == []
+
+    def test_list_versions_sorted(self, reg, dummy_model):
+        reg.register(dummy_model)
+        reg.register(dummy_model)
+        reg.register(dummy_model)
+        versions = reg.list_versions()
+        nums = [v["version"] for v in versions]
+        assert nums == sorted(nums)
+
+    def test_copy_files_stores_checkpoint(self, reg, dummy_model):
+        ver = reg.register(dummy_model, copy_files=True)
+        meta = reg.get_version(ver)
+        assert Path(meta["model_path"]).exists()
+
+    def test_no_copy_records_path_only(self, reg, dummy_model):
+        ver = reg.register(dummy_model, copy_files=False)
+        meta = reg.get_version(ver)
+        assert meta["model_path"] == dummy_model
+
+
+class TestModelRegistryActive:
+    def test_active_none_initially(self, reg):
+        assert reg.get_active() is None
+
+    def test_set_active_updates_pointer(self, reg, dummy_model):
+        ver = reg.register(dummy_model)
+        reg.set_active(ver)
+        active = reg.get_active()
+        assert active is not None
+        assert active["version"] == ver
+
+    def test_set_active_unknown_raises(self, reg):
+        with pytest.raises(KeyError):
+            reg.set_active(999)
+
+    def test_is_active_flag_in_list(self, reg, dummy_model):
+        v1 = reg.register(dummy_model)
+        v2 = reg.register(dummy_model)
+        reg.set_active(v2)
+        lst = {v["version"]: v for v in reg.list_versions()}
+        assert not lst[v1]["is_active"]
+        assert lst[v2]["is_active"]
+
+
+class TestModelRegistryRollback:
+    def test_rollback_sets_active(self, reg, dummy_model):
+        v1 = reg.register(dummy_model)
+        v2 = reg.register(dummy_model)
+        reg.set_active(v2)
+        reg.rollback(v1)
+        assert reg.get_active()["version"] == v1
+
+    def test_rollback_copies_to_target_path(self, reg, dummy_model, tmp_path):
+        ver = reg.register(dummy_model)
+        target = str(tmp_path / "active" / "model.zip")
+        reg.rollback(ver, active_model_path=target)
+        assert Path(target).exists()
+
+    def test_rollback_unknown_raises(self, reg):
+        with pytest.raises(KeyError):
+            reg.rollback(999)
+
+
+class TestModelRegistryDelete:
+    def test_delete_removes_from_index(self, reg, dummy_model):
+        v1 = reg.register(dummy_model)
+        v2 = reg.register(dummy_model)
+        reg.delete_version(v1)
+        with pytest.raises(KeyError):
+            reg.get_version(v1)
+        assert reg.get_version(v2) is not None
+
+    def test_delete_active_raises(self, reg, dummy_model):
+        ver = reg.register(dummy_model)
+        reg.set_active(ver)
+        with pytest.raises(ValueError):
+            reg.delete_version(ver)
+
+
+class TestRollbackScript:
+    """Integration test: rollback_model.py CLI."""
+
+    def test_list_flag(self, reg, dummy_model):
+        reg.register(dummy_model, tag="v1-tag")
+        result = subprocess.run(
+            [sys.executable, "scripts/rollback_model.py", "--list",
+             "--registry-dir", str(reg._dir)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "v1-tag" in result.stdout
+
+    def test_rollback_via_cli(self, reg, dummy_model):
+        ver = reg.register(dummy_model)
+        result = subprocess.run(
+            [sys.executable, "scripts/rollback_model.py", str(ver),
+             "--registry-dir", str(reg._dir)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert f"version {ver}" in result.stdout
+
+    def test_rollback_unknown_version_exits_nonzero(self, reg):
+        result = subprocess.run(
+            [sys.executable, "scripts/rollback_model.py", "999",
+             "--registry-dir", str(reg._dir)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0

--- a/training/registry/model_registry.py
+++ b/training/registry/model_registry.py
@@ -1,0 +1,257 @@
+"""
+Model Registry — lightweight, file-based (no MLflow required).
+
+Week 67 (S59): Store model versions, metrics, and config on disk so that
+Week 68 (S62) rollback is possible.
+
+Layout (under ``registry_dir``):
+    <registry_dir>/
+        registry.json       ← index of all versions
+        models/
+            v<N>/
+                model.*     ← checkpoint file(s) copied here
+                meta.json   ← version, metrics, config, timestamp, path
+
+Usage::
+
+    reg = ModelRegistry()
+    ver = reg.register(
+        model_path="/path/to/model.zip",
+        metrics={"sharpe": 1.2, "max_dd": 0.08},
+        config={"algo": "PPO", "learning_rate": 3e-4},
+        tag="post-week66",
+    )
+    reg.set_active(ver)
+    active = reg.get_active()    # returns meta dict
+    reg.rollback(target_version) # copies version to active_model slot
+
+Thread-safe for concurrent reads; writes are serialised with a file lock.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_REGISTRY_DIR = os.path.join(
+    os.path.expanduser("~"), ".trading_bot", "model_registry"
+)
+
+
+class ModelRegistry:
+    """
+    Local file-based model registry.
+
+    Parameters
+    ----------
+    registry_dir : str
+        Root directory for the registry.  Created on first use.
+    """
+
+    def __init__(self, registry_dir: str = _DEFAULT_REGISTRY_DIR) -> None:
+        self._dir = Path(registry_dir)
+        self._dir.mkdir(parents=True, exist_ok=True)
+        (self._dir / "models").mkdir(exist_ok=True)
+        self._lock = threading.Lock()
+        self._index_path = self._dir / "registry.json"
+
+        if not self._index_path.exists():
+            self._write_index({"versions": {}, "active": None})
+        logger.info("ModelRegistry at %s", self._dir)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def register(
+        self,
+        model_path: str,
+        metrics: Optional[Dict[str, float]] = None,
+        config: Optional[Dict[str, Any]] = None,
+        tag: Optional[str] = None,
+        copy_files: bool = True,
+    ) -> int:
+        """Register a new model version.
+
+        Parameters
+        ----------
+        model_path :
+            Path to the model checkpoint file (or directory).
+        metrics :
+            Performance metrics at time of registration.
+        config :
+            Training / architecture config.
+        tag :
+            Optional free-text label.
+        copy_files :
+            If True (default), copy the checkpoint into the registry.
+            Set to False if you only want to record the external path.
+
+        Returns
+        -------
+        int
+            The assigned version number.
+        """
+        with self._lock:
+            index = self._read_index()
+            existing = index.get("versions", {})
+            version = max((int(v) for v in existing), default=0) + 1
+
+            version_dir = self._dir / "models" / f"v{version}"
+            version_dir.mkdir(parents=True, exist_ok=True)
+
+            stored_path = str(model_path)
+            if copy_files:
+                src = Path(model_path)
+                if src.is_dir():
+                    dst = version_dir / src.name
+                    shutil.copytree(src, dst, dirs_exist_ok=True)
+                    stored_path = str(dst)
+                elif src.is_file():
+                    dst = version_dir / src.name
+                    shutil.copy2(src, dst)
+                    stored_path = str(dst)
+                else:
+                    logger.warning("model_path does not exist on disk: %s (path recorded only)", model_path)
+                    stored_path = str(model_path)
+
+            meta: Dict[str, Any] = {
+                "version": version,
+                "registered_at": datetime.now(timezone.utc).isoformat(),
+                "model_path": stored_path,
+                "original_path": str(model_path),
+                "metrics": metrics or {},
+                "config": config or {},
+                "tag": tag or "",
+            }
+            meta_path = version_dir / "meta.json"
+            meta_path.write_text(json.dumps(meta, indent=2))
+
+            index.setdefault("versions", {})[str(version)] = {
+                "meta_path": str(meta_path),
+                "registered_at": meta["registered_at"],
+                "tag": tag or "",
+            }
+            self._write_index(index)
+
+        logger.info("Registered model version %d from %s", version, model_path)
+        return version
+
+    def set_active(self, version: int) -> None:
+        """Mark a registered version as the active model."""
+        with self._lock:
+            index = self._read_index()
+            if str(version) not in index.get("versions", {}):
+                raise KeyError(f"Version {version} not found in registry")
+            index["active"] = version
+            self._write_index(index)
+        logger.info("Active model set to version %d", version)
+
+    def get_active(self) -> Optional[Dict[str, Any]]:
+        """Return metadata dict for the active version, or None."""
+        index = self._read_index()
+        active = index.get("active")
+        if active is None:
+            return None
+        return self.get_version(int(active))
+
+    def get_version(self, version: int) -> Dict[str, Any]:
+        """Return metadata dict for a specific version.
+
+        Raises
+        ------
+        KeyError
+            If the version is not registered.
+        """
+        index = self._read_index()
+        entry = index.get("versions", {}).get(str(version))
+        if entry is None:
+            raise KeyError(f"Version {version} not in registry")
+        meta_path = Path(entry["meta_path"])
+        if not meta_path.exists():
+            raise FileNotFoundError(f"meta.json missing for version {version}: {meta_path}")
+        return json.loads(meta_path.read_text())
+
+    def list_versions(self) -> List[Dict[str, Any]]:
+        """Return summary of all registered versions (sorted ascending)."""
+        index = self._read_index()
+        result = []
+        active = index.get("active")
+        for v_str, entry in sorted(index.get("versions", {}).items(), key=lambda x: int(x[0])):
+            result.append({
+                "version": int(v_str),
+                "registered_at": entry.get("registered_at", ""),
+                "tag": entry.get("tag", ""),
+                "is_active": int(v_str) == active,
+            })
+        return result
+
+    def rollback(self, target_version: int, active_model_path: Optional[str] = None) -> str:
+        """Switch the active model to ``target_version``.
+
+        If ``active_model_path`` is given, the checkpoint file stored for
+        ``target_version`` is also copied there so that a restarted
+        PaperTrader picks it up automatically.
+
+        Returns
+        -------
+        str
+            Path to the rolled-back model checkpoint.
+        """
+        meta = self.get_version(target_version)
+        stored = Path(meta["model_path"])
+
+        if active_model_path is not None:
+            dst = Path(active_model_path)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if stored.is_dir():
+                shutil.copytree(stored, dst, dirs_exist_ok=True)
+            elif stored.is_file():
+                shutil.copy2(stored, dst)
+            else:
+                logger.warning("Stored path for version %d not found: %s", target_version, stored)
+
+        self.set_active(target_version)
+        logger.info("Rolled back to version %d (stored at %s)", target_version, stored)
+        return str(stored)
+
+    def delete_version(self, version: int) -> None:
+        """Remove a version from the registry (does NOT delete files by default)."""
+        with self._lock:
+            index = self._read_index()
+            versions = index.get("versions", {})
+            if str(version) not in versions:
+                raise KeyError(f"Version {version} not found")
+            if index.get("active") == version:
+                raise ValueError(
+                    f"Cannot delete active version {version}. "
+                    "Set a different active version first."
+                )
+            del versions[str(version)]
+            index["versions"] = versions
+            self._write_index(index)
+        logger.info("Deleted version %d from registry index", version)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _read_index(self) -> Dict[str, Any]:
+        try:
+            return json.loads(self._index_path.read_text())
+        except Exception as e:
+            logger.warning("Failed to read registry index: %s", e)
+            return {"versions": {}, "active": None}
+
+    def _write_index(self, index: Dict[str, Any]) -> None:
+        tmp = self._index_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(index, indent=2))
+        tmp.replace(self._index_path)


### PR DESCRIPTION
## Summary

- **S61**: `shadow_agent` 옵션을 `PaperTrader`에 추가. 매 step main agent와 동일한 obs로 predict() 실행하되 주문 안 냄. 결정은 audit log에 `source=shadow`로 기록. `AuditLogger.log_model_decision`에 `extra` kwarg 추가.
- **S62**: `training/registry/model_registry.py` 파일 기반 경량 모델 레지스트리 (MLflow 불필요). `register/set_active/rollback/list_versions/delete_version`. `scripts/rollback_model.py` CLI (`--list`, `--show`, `--active-model-path`).
- **S63**: `scripts/phase6_smoke.py` — Track A/B/C/D 전체 기능 33개 체크, 단일 실행으로 end-to-end 검증. Exit 0 확인.
- **S64**: 최종 회귀 **1727 passed, 19 skipped, 0 failed** (baseline 1386 + Phase 6 신규 341).
- **S65**: `docs/phase6/week68.md` 회고 + `docs/phase6/RETRO.md` Phase 6 전체 완료 체크리스트.

## Test plan

- [x] `pytest tests/deployment/test_shadow_mode.py` — 7 passed
- [x] `pytest tests/training/test_model_registry.py` — 20 passed
- [x] `python scripts/phase6_smoke.py` — 33/33 passed, exit 0
- [x] `python -m pytest -q` — 1727 passed, 0 failed
- [x] Shadow agent decisions appear in audit log with `source=shadow`
- [x] `scripts/rollback_model.py --list` works, rollback changes active version
- [x] Audit chain verification passes after shadow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)