### PR TITLE
Week 73: Position Reconciliation on Startup (F7-F11)

### DIFF
--- a/data/sources/ccxt_live.py
+++ b/data/sources/ccxt_live.py
@@ -1,0 +1,137 @@
+"""
+CCXTLiveDataSource — Week 72 (F2)
+
+Wraps a CCXTAdapter (WebSocket feed) to implement the DataSource contract
+used by PaperTrader and SingleAssetRLTradingEnv.  Data arrives as OHLCV bars
+pushed from the adapter callback; the buffer is thread-safe.
+
+Staleness tracking (S47) is integrated: ``last_updated_at()`` and
+``is_stale()`` work identically to MockLiveDataSource.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import deque
+from typing import List, Optional
+
+import pandas as pd
+
+from data.sources.base import DataSource
+
+logger = logging.getLogger(__name__)
+
+# Column names for live OHLCV bars.
+_ENV_COLS: List[str] = ["open", "high", "low", "close", "volume"]
+
+# Minimum bar length expected from CCXT: [timestamp, open, high, low, close, volume]
+_MIN_BAR_LEN = 6
+
+
+class CCXTLiveDataSource(DataSource):
+    """
+    Live OHLCV data source backed by a CCXTAdapter WebSocket feed.
+
+    Parameters
+    ----------
+    adapter :
+        A CCXTAdapter (or compatible mock) that provides
+        ``add_ohlcv_callback(fn)``.
+    max_bars : int
+        Rolling buffer depth (default 500).
+    max_staleness_sec : float
+        If > 0, ``is_stale()`` uses this as the default threshold.
+        Pass 0 to require an explicit threshold per call.
+    """
+
+    def __init__(
+        self,
+        adapter,
+        max_bars: int = 500,
+        max_staleness_sec: float = 0.0,
+    ) -> None:
+        self._buffer: deque = deque(maxlen=max_bars)
+        self._lock = threading.Lock()
+        self._last_updated_at: Optional[float] = None
+        self.max_staleness_sec = max_staleness_sec
+
+        adapter.add_ohlcv_callback(self._on_ohlcv)
+
+    # ------------------------------------------------------------------
+    # Callback from CCXTAdapter
+    # ------------------------------------------------------------------
+
+    def _on_ohlcv(self, bars: list) -> None:
+        """Receive a batch of CCXT OHLCV bars and append to the buffer."""
+        with self._lock:
+            for bar in bars:
+                if len(bar) < _MIN_BAR_LEN:
+                    logger.debug("_on_ohlcv: skipping malformed bar (len=%d)", len(bar))
+                    continue
+                _, o, h, l, c, v = bar[0], bar[1], bar[2], bar[3], bar[4], bar[5]
+                self._buffer.append([float(o), float(h), float(l), float(c), float(v)])
+            if bars:
+                self._last_updated_at = time.monotonic()
+
+    # ------------------------------------------------------------------
+    # S47 — Staleness interface (same contract as MockLiveDataSource)
+    # ------------------------------------------------------------------
+
+    def last_updated_at(self) -> Optional[float]:
+        """Monotonic timestamp of the last received bar, or None if no data."""
+        with self._lock:
+            return self._last_updated_at
+
+    def is_stale(self, max_staleness_sec: float = 0.0) -> bool:
+        """True if the feed hasn't updated within *max_staleness_sec* seconds.
+
+        Falls back to ``self.max_staleness_sec`` when the argument is 0.
+        Returns False if both thresholds are 0 (staleness check disabled).
+        """
+        threshold = max_staleness_sec if max_staleness_sec > 0 else self.max_staleness_sec
+        if threshold <= 0:
+            return False
+        with self._lock:
+            last = self._last_updated_at
+        if last is None:
+            return True
+        return (time.monotonic() - last) > threshold
+
+    # ------------------------------------------------------------------
+    # DataSource interface
+    # ------------------------------------------------------------------
+
+    def is_live(self) -> bool:
+        return True
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._buffer)
+
+    def latest(self) -> pd.Series:
+        """Return the most recent bar as a Series.
+
+        Raises RuntimeError if no data has been received yet.
+        """
+        with self._lock:
+            if not self._buffer:
+                raise RuntimeError("CCXTLiveDataSource: no data received yet")
+            row = self._buffer[-1]
+        return pd.Series(row, index=_ENV_COLS, dtype=float)
+
+    def get_window(self, start: int, end: int) -> pd.DataFrame:
+        """Return bars [start, end) as a DataFrame.
+
+        Clamps *start* to 0 and *end* to ``len(self)``.
+        Returns an empty DataFrame with correct columns if out of range.
+        """
+        with self._lock:
+            rows = list(self._buffer)
+        n = len(rows)
+        s = max(0, start)
+        e = min(end, n)
+        if s >= e:
+            return pd.DataFrame(columns=_ENV_COLS)
+        return pd.DataFrame(rows[s:e], columns=_ENV_COLS, dtype=float)

--- a/deployment/exchange/snapshot.py
+++ b/deployment/exchange/snapshot.py
@@ -1,0 +1,139 @@
+"""
+Exchange Snapshot — Week 73 (F7)
+
+Point-in-time read of exchange state: positions, open orders, balance.
+All methods are best-effort: they return empty/zero on failure so callers
+can decide severity (F8 halt policy lives in PaperTrader, not here).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ExchangeSnapshot:
+    """
+    Wraps CCXT REST calls to produce a point-in-time exchange snapshot.
+
+    Parameters
+    ----------
+    exchange :
+        Initialised CCXT exchange object with REST credentials.
+    symbol : str
+        Default trading pair, e.g. ``"BTC/USDT"``.
+    """
+
+    def __init__(self, exchange, symbol: str = "BTC/USDT") -> None:
+        self._exchange = exchange
+        self.symbol = symbol
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_positions(self, symbol: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Fetch open positions for *symbol*.
+
+        Returns a list of normalised position dicts::
+
+            {"symbol": str, "qty": float, "entry_price": float,
+             "side": str, "unrealised_pnl": float}
+
+        Returns ``[]`` on API error or missing ``fetch_positions`` support.
+        """
+        sym = symbol or self.symbol
+        try:
+            raw = self._exchange.fetch_positions([sym])
+            return [self._normalise_position(p) for p in raw]
+        except Exception as exc:
+            logger.warning("ExchangeSnapshot.get_positions failed: %s", exc)
+            return []
+
+    def get_open_orders(self, symbol: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Fetch all open orders for *symbol*.
+
+        Returns a list of normalised order dicts::
+
+            {"order_id": str, "symbol": str, "side": str, "amount": float,
+             "filled": float, "remaining": float, "price": float,
+             "type": str, "status": str}
+
+        Returns ``[]`` on API error.
+        """
+        sym = symbol or self.symbol
+        try:
+            raw = self._exchange.fetch_open_orders(sym)
+            return [self._normalise_order(o) for o in raw]
+        except Exception as exc:
+            logger.warning("ExchangeSnapshot.get_open_orders failed: %s", exc)
+            return []
+
+    def get_balance(self) -> Dict[str, Any]:
+        """Fetch account balance.
+
+        Returns::
+
+            {"free": {asset: float}, "used": {asset: float},
+             "total": {asset: float}}
+
+        Returns empty sub-dicts on API error.
+        """
+        try:
+            raw = self._exchange.fetch_balance()
+            return {
+                "free":  {k: float(v) for k, v in (raw.get("free") or {}).items() if v},
+                "used":  {k: float(v) for k, v in (raw.get("used") or {}).items() if v},
+                "total": {k: float(v) for k, v in (raw.get("total") or {}).items() if v},
+            }
+        except Exception as exc:
+            logger.warning("ExchangeSnapshot.get_balance failed: %s", exc)
+            return {"free": {}, "used": {}, "total": {}}
+
+    def snapshot(self, symbol: Optional[str] = None) -> Dict[str, Any]:
+        """Convenience: positions + open orders + balance in one call.
+
+        Returns::
+
+            {"symbol": str, "positions": [...], "open_orders": [...],
+             "balance": {...}}
+        """
+        sym = symbol or self.symbol
+        return {
+            "symbol":      sym,
+            "positions":   self.get_positions(sym),
+            "open_orders": self.get_open_orders(sym),
+            "balance":     self.get_balance(),
+        }
+
+    # ------------------------------------------------------------------
+    # Normalisation helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalise_position(raw: Dict[str, Any]) -> Dict[str, Any]:
+        qty = raw.get("contracts") or raw.get("amount") or raw.get("size") or 0
+        entry = raw.get("entryPrice") or raw.get("avgPrice") or raw.get("average") or 0
+        return {
+            "symbol":        raw.get("symbol", ""),
+            "qty":           float(qty),
+            "entry_price":   float(entry),
+            "side":          (raw.get("side") or "long").lower(),
+            "unrealised_pnl": float(raw.get("unrealizedPnl") or 0),
+        }
+
+    @staticmethod
+    def _normalise_order(raw: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "order_id":  str(raw.get("id", "")),
+            "symbol":    raw.get("symbol", ""),
+            "side":      (raw.get("side") or "").lower(),
+            "amount":    float(raw.get("amount") or 0),
+            "filled":    float(raw.get("filled") or 0),
+            "remaining": float(raw.get("remaining") or 0),
+            "price":     float(raw.get("price") or 0),
+            "type":      raw.get("type", "market"),
+            "status":    raw.get("status", "open"),
+        }

--- a/deployment/execution/order_manager.py
+++ b/deployment/execution/order_manager.py
@@ -186,6 +186,11 @@ class OrderManager:
         self._halted: bool = False
         # S52: latency tracking (submit-to-fill, ms)
         self._latency_samples: List[float] = []
+        # F11: throttle clock-skew checks to avoid per-order exchange round trips
+        self._clock_check_interval: float = float(
+            exchange_config.get("clock_check_interval_sec", 30.0)
+        )
+        self._last_clock_check_at: float = 0.0
         self._position_tracker = PositionTracker(
             initial_cash=float(exchange_config.get("initial_cash", 10_000.0))
         )
@@ -228,6 +233,13 @@ class OrderManager:
 
         if self._halted:
             raise RuntimeError("Daily loss limit breached — trading halted.")
+
+        # F11: proactively measure clock drift (throttled to avoid per-order RTT).
+        # check() updates is_halted when halt_on_skew=True and drift > threshold.
+        _now = time.monotonic()
+        if not self.paper_mode and _now - self._last_clock_check_at >= self._clock_check_interval:
+            self._clock_sync.check()
+            self._last_clock_check_at = _now
 
         # S45: clock skew halt
         if self._clock_sync.is_halted:

--- a/deployment/paper_trader.py
+++ b/deployment/paper_trader.py
@@ -29,6 +29,7 @@ import numpy as np
 
 from deployment.analysis.pnl_attribution import PnLAttributor
 from deployment.audit.audit_logger import AuditLogger
+from deployment.exchange.snapshot import ExchangeSnapshot
 from deployment.execution.order_manager import OrderManager
 from deployment.execution.position_tracker import PositionTracker
 from deployment.monitoring.alerter import TradingAlerter
@@ -239,6 +240,7 @@ class PaperTrader:
         regime_detector: Optional[RegimeDetector] = None,
         feature_drift_detector: Optional[FeatureDriftDetector] = None,
         on_regime_change: Optional[Callable[[int, int, np.ndarray], None]] = None,
+        exchange_snapshot: Optional[ExchangeSnapshot] = None,  # F7/F8/F9
     ) -> None:
         self.agent = agent
         self.config = config
@@ -302,6 +304,15 @@ class PaperTrader:
         self._nan_check_enabled: bool = bool(pipeline_cfg.get("nan_check_enabled", True))
         self._nan_halt_after_n: int = int(pipeline_cfg.get("nan_halt_after_n", 5))
         self._consecutive_nan_steps: int = 0
+
+        # F7/F8/F9: exchange reconciliation
+        self.exchange_snapshot: Optional[ExchangeSnapshot] = exchange_snapshot
+        recon_cfg = config.get("reconciliation", {}) or {}
+        self._on_mismatch: str = recon_cfg.get("on_mismatch", "halt")  # halt|warn|ignore
+        self._recon_qty_threshold: float = float(recon_cfg.get("qty_threshold", 0.001))
+        self._recon_price_threshold: float = float(recon_cfg.get("price_threshold", 0.001))
+        self._recon_interval_sec: float = float(recon_cfg.get("interval_sec", 60.0))
+        self._last_reconcile_at: float = 0.0
 
         if not simulation_mode:
             self._exchange = self._init_exchange(pt)
@@ -382,6 +393,8 @@ class PaperTrader:
             self._check_regime()
             self._run_shadow_agent(obs, step)
             self._maybe_daily_report()
+            # F9: periodic exchange reconciliation
+            self._periodic_reconcile(time.time())
 
             step += 1
             self.state.step = step
@@ -509,6 +522,8 @@ class PaperTrader:
             trader.state.balance,
             trader.state.position,
         )
+        # F8: reconcile local state against exchange immediately after restore
+        trader._reconcile_on_boot()
         return trader
 
     def save_checkpoint(self, path: str) -> None:
@@ -799,6 +814,142 @@ class PaperTrader:
                     self.on_regime_change(prev, new_regime, probs)
                 except Exception as exc:
                     logger.warning("on_regime_change hook raised: %s", exc)
+
+    # ------------------------------------------------------------------
+    # F8/F9: Exchange reconciliation
+    # ------------------------------------------------------------------
+
+    def _reconcile_on_boot(self) -> None:
+        """F8: Compare restored local state against live exchange snapshot."""
+        if self.exchange_snapshot is None:
+            return
+        logger.info("Reconcile-on-boot: fetching exchange snapshot for %s", self.symbol)
+        result = self._do_reconcile()
+        self._last_reconcile_at = time.time()
+        if result["ok"]:
+            logger.info("Reconcile-on-boot: OK (no mismatches)")
+        else:
+            logger.warning(
+                "Reconcile-on-boot: %d mismatch(es) detected: %s",
+                len(result["diffs"]),
+                result["diffs"],
+            )
+            self._handle_mismatch(result["diffs"], context="boot")
+
+    def _periodic_reconcile(self, current_time: float) -> None:
+        """F9: Reconcile every _recon_interval_sec seconds during run loop."""
+        if self.exchange_snapshot is None:
+            return
+        if current_time - self._last_reconcile_at < self._recon_interval_sec:
+            return
+        self._last_reconcile_at = current_time
+        result = self._do_reconcile()
+        if not result["ok"]:
+            logger.warning(
+                "Periodic reconcile: %d mismatch(es): %s",
+                len(result["diffs"]),
+                result["diffs"],
+            )
+            self._handle_mismatch(result["diffs"], context="periodic")
+
+    def _do_reconcile(self) -> Dict[str, Any]:
+        """Core reconcile: compare local state with exchange snapshot.
+
+        Returns dict with keys: ok (bool), diffs (list), local_qty, exchange_qty.
+        """
+        sym = self.symbol
+        try:
+            snap = self.exchange_snapshot.snapshot(sym)
+        except Exception as exc:
+            logger.error("Reconcile: snapshot fetch failed: %s", exc)
+            return {"ok": True, "diffs": [], "local_qty": 0.0, "exchange_qty": 0.0}
+
+        local_qty = self.state.position
+        local_entry = self.state.entry_price
+
+        # Sum up exchange position qty for this symbol
+        exchange_qty = 0.0
+        exchange_entry = 0.0
+        base = sym.split("/")[0]
+        for pos in snap["positions"]:
+            pos_sym = pos.get("symbol", "")
+            if pos_sym == sym or pos_sym.startswith(base):
+                exchange_qty += pos["qty"]
+                exchange_entry = pos["entry_price"]
+
+        # Fall back to balance for spot exchanges that don't support fetch_positions
+        if exchange_qty == 0.0 and not snap["positions"]:
+            exchange_qty = float(snap["balance"]["free"].get(base, 0))
+
+        diffs: List[Dict[str, Any]] = []
+
+        # Qty mismatch
+        qty_diff = abs(local_qty - exchange_qty)
+        if qty_diff > self._recon_qty_threshold:
+            diffs.append({
+                "type": "qty_mismatch",
+                "local_qty": local_qty,
+                "exchange_qty": exchange_qty,
+                "diff": qty_diff,
+            })
+
+        # Price drift (only meaningful when both sides hold a position)
+        if local_qty > self._recon_qty_threshold and exchange_entry > 0:
+            price_diff = abs(local_entry - exchange_entry)
+            rel_drift = price_diff / exchange_entry if exchange_entry else 0.0
+            if rel_drift > self._recon_price_threshold:
+                diffs.append({
+                    "type": "price_drift",
+                    "local_entry": local_entry,
+                    "exchange_entry": exchange_entry,
+                    "rel_drift": rel_drift,
+                })
+
+        # Open orders mismatch
+        exchange_open_count = len(snap["open_orders"])
+        local_open_count = 0
+        if self.order_manager is not None:
+            with self.order_manager._lock:
+                local_open_count = sum(
+                    1 for o in self.order_manager._orders.values()
+                    if o.status in ("pending", "partial")
+                )
+        if local_open_count != exchange_open_count:
+            diffs.append({
+                "type": "open_orders_mismatch",
+                "local_open": local_open_count,
+                "exchange_open": exchange_open_count,
+            })
+
+        # Audit every reconcile result
+        if self.audit_logger is not None:
+            self.audit_logger.log_risk_event({
+                "type": "reconcile",
+                "ok": len(diffs) == 0,
+                "diffs": diffs,
+                "local_qty": local_qty,
+                "exchange_qty": exchange_qty,
+                "step": self.state.step,
+            })
+
+        return {
+            "ok": len(diffs) == 0,
+            "diffs": diffs,
+            "local_qty": local_qty,
+            "exchange_qty": exchange_qty,
+            "snapshot": snap,
+        }
+
+    def _handle_mismatch(self, diffs: List[Dict[str, Any]], context: str = "") -> None:
+        """Act on detected mismatches according to on_mismatch config."""
+        msg = f"Position mismatch [{context}]: {diffs}"
+        if self.alerter is not None:
+            self.alerter.send_alert(msg, level="ERROR")
+        if self._on_mismatch == "halt":
+            self._trigger_shutdown(f"reconcile_halt: {msg}")
+        elif self._on_mismatch == "warn":
+            logger.warning("on_mismatch=warn: %s", msg)
+        # "ignore": log already happened in _do_reconcile
 
     def _trigger_shutdown(self, reason: str) -> None:
         logger.warning("SHUTDOWN triggered: %s", reason)

--- a/tests/exchange/test_snapshot.py
+++ b/tests/exchange/test_snapshot.py
@@ -1,0 +1,599 @@
+"""
+Tests for ExchangeSnapshot (F7) and reconcile-on-boot / periodic reconcile (F8, F9, F10).
+
+Scenarios covered:
+  - ExchangeSnapshot.get_positions / get_open_orders / get_balance (happy path + errors)
+  - ExchangeSnapshot.snapshot convenience wrapper
+  - _do_reconcile: no mismatch, qty mismatch, price drift, open-orders mismatch
+  - _reconcile_on_boot: halt | warn | ignore on mismatch
+  - _periodic_reconcile: throttling, triggered after interval
+  - Bootstrap: PaperTrader.restore() calls reconcile-on-boot
+  - Bootstrap: forced position mismatch detected on startup
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deployment.exchange.snapshot import ExchangeSnapshot
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_exchange(
+    positions=None,
+    open_orders=None,
+    balance=None,
+    positions_error=False,
+    orders_error=False,
+    balance_error=False,
+):
+    """Build a minimal mock CCXT exchange."""
+    ex = MagicMock()
+    if positions_error:
+        ex.fetch_positions.side_effect = RuntimeError("positions unavailable")
+    else:
+        ex.fetch_positions.return_value = positions or []
+    if orders_error:
+        ex.fetch_open_orders.side_effect = RuntimeError("orders unavailable")
+    else:
+        ex.fetch_open_orders.return_value = open_orders or []
+    if balance_error:
+        ex.fetch_balance.side_effect = RuntimeError("balance unavailable")
+    else:
+        ex.fetch_balance.return_value = balance or {"free": {}, "used": {}, "total": {}}
+    return ex
+
+
+def _ccxt_position(symbol="BTC/USDT", qty=0.5, entry=50_000.0, side="long"):
+    return {
+        "symbol": symbol,
+        "contracts": qty,
+        "entryPrice": entry,
+        "side": side,
+        "unrealizedPnl": 100.0,
+    }
+
+
+def _ccxt_order(order_id="o1", symbol="BTC/USDT", side="buy", amount=0.01):
+    return {
+        "id": order_id,
+        "symbol": symbol,
+        "side": side,
+        "amount": amount,
+        "filled": 0.0,
+        "remaining": amount,
+        "price": 50_000.0,
+        "type": "limit",
+        "status": "open",
+    }
+
+
+# ---------------------------------------------------------------------------
+# F7 — ExchangeSnapshot unit tests
+# ---------------------------------------------------------------------------
+
+class TestExchangeSnapshotGetPositions:
+    def test_happy_path_normalises_fields(self):
+        ex = _make_exchange(positions=[_ccxt_position(qty=1.0, entry=40_000.0)])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        result = snap.get_positions("BTC/USDT")
+        assert len(result) == 1
+        p = result[0]
+        assert p["symbol"] == "BTC/USDT"
+        assert p["qty"] == pytest.approx(1.0)
+        assert p["entry_price"] == pytest.approx(40_000.0)
+        assert p["side"] == "long"
+
+    def test_returns_empty_list_on_error(self):
+        ex = _make_exchange(positions_error=True)
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        result = snap.get_positions()
+        assert result == []
+
+    def test_uses_default_symbol(self):
+        ex = _make_exchange(positions=[_ccxt_position()])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        snap.get_positions()
+        ex.fetch_positions.assert_called_once_with(["BTC/USDT"])
+
+    def test_uses_provided_symbol(self):
+        ex = _make_exchange(positions=[])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        snap.get_positions("ETH/USDT")
+        ex.fetch_positions.assert_called_once_with(["ETH/USDT"])
+
+    def test_zero_qty_position(self):
+        raw = {"symbol": "BTC/USDT", "contracts": None, "amount": None,
+               "entryPrice": None, "side": None, "unrealizedPnl": None}
+        ex = _make_exchange(positions=[raw])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        result = snap.get_positions()
+        assert result[0]["qty"] == 0.0
+        assert result[0]["side"] == "long"
+
+
+class TestExchangeSnapshotGetOpenOrders:
+    def test_happy_path(self):
+        ex = _make_exchange(open_orders=[_ccxt_order(order_id="abc", amount=0.05)])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        result = snap.get_open_orders()
+        assert len(result) == 1
+        o = result[0]
+        assert o["order_id"] == "abc"
+        assert o["amount"] == pytest.approx(0.05)
+        assert o["side"] == "buy"
+
+    def test_returns_empty_on_error(self):
+        ex = _make_exchange(orders_error=True)
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        assert snap.get_open_orders() == []
+
+    def test_multiple_orders(self):
+        orders = [_ccxt_order(order_id=f"o{i}") for i in range(3)]
+        ex = _make_exchange(open_orders=orders)
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        assert len(snap.get_open_orders()) == 3
+
+
+class TestExchangeSnapshotGetBalance:
+    def test_happy_path(self):
+        raw = {
+            "free":  {"BTC": 0.5, "USDT": 10_000.0},
+            "used":  {"BTC": 0.0},
+            "total": {"BTC": 0.5, "USDT": 10_000.0},
+        }
+        ex = _make_exchange(balance=raw)
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        result = snap.get_balance()
+        assert result["free"]["BTC"] == pytest.approx(0.5)
+        assert result["free"]["USDT"] == pytest.approx(10_000.0)
+
+    def test_returns_empty_on_error(self):
+        ex = _make_exchange(balance_error=True)
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        result = snap.get_balance()
+        assert result == {"free": {}, "used": {}, "total": {}}
+
+    def test_filters_none_values(self):
+        raw = {"free": {"BTC": 0.5, "USDT": None}, "used": {}, "total": {}}
+        ex = _make_exchange(balance=raw)
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        result = snap.get_balance()
+        assert "USDT" not in result["free"]
+
+
+class TestExchangeSnapshotConvenience:
+    def test_snapshot_returns_all_three(self):
+        ex = _make_exchange(
+            positions=[_ccxt_position()],
+            open_orders=[_ccxt_order()],
+            balance={"free": {"BTC": 0.5}, "used": {}, "total": {}},
+        )
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        result = snap.snapshot()
+        assert result["symbol"] == "BTC/USDT"
+        assert len(result["positions"]) == 1
+        assert len(result["open_orders"]) == 1
+        assert "BTC" in result["balance"]["free"]
+
+
+# ---------------------------------------------------------------------------
+# F8/F9/F10 — PaperTrader reconciliation scenarios
+# ---------------------------------------------------------------------------
+
+def _make_trader(
+    position: float = 0.0,
+    entry_price: float = 0.0,
+    exchange_snapshot=None,
+    on_mismatch: str = "halt",
+    qty_threshold: float = 0.001,
+    price_threshold: float = 0.001,
+    interval_sec: float = 60.0,
+):
+    """Build a minimal PaperTrader for reconciliation testing."""
+    from deployment.paper_trader import PaperTrader
+
+    agent = MagicMock()
+    agent.predict.return_value = (0.0, None)
+    config = {
+        "paper_trading": {
+            "symbol": "BTC/USDT",
+            "initial_balance": 10_000.0,
+            "window_size": 5,
+        },
+        "reconciliation": {
+            "on_mismatch": on_mismatch,
+            "qty_threshold": qty_threshold,
+            "price_threshold": price_threshold,
+            "interval_sec": interval_sec,
+        },
+    }
+    trader = PaperTrader(
+        agent=agent,
+        config=config,
+        simulation_mode=True,
+        exchange_snapshot=exchange_snapshot,
+    )
+    # Manually set position state
+    if position > 0:
+        trader.state.pos.apply_buy(position, entry_price, fee=0.0)
+    return trader
+
+
+class TestDoReconcile:
+    def test_no_mismatch_ok(self):
+        """Local and exchange agree → ok=True, no diffs."""
+        ex = _make_exchange(
+            positions=[_ccxt_position(qty=0.5, entry=50_000.0)],
+            open_orders=[],
+        )
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(position=0.5, entry_price=50_000.0,
+                               exchange_snapshot=snap)
+        result = trader._do_reconcile()
+        assert result["ok"] is True
+        assert result["diffs"] == []
+
+    def test_qty_mismatch_detected(self):
+        """Exchange has 0.5, local has 0.0 → qty_mismatch diff."""
+        ex = _make_exchange(
+            positions=[_ccxt_position(qty=0.5, entry=50_000.0)],
+            open_orders=[],
+        )
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(position=0.0, exchange_snapshot=snap)
+        result = trader._do_reconcile()
+        assert result["ok"] is False
+        types = [d["type"] for d in result["diffs"]]
+        assert "qty_mismatch" in types
+
+    def test_price_drift_detected(self):
+        """Entry price differs by 10% → price_drift diff."""
+        ex = _make_exchange(
+            positions=[_ccxt_position(qty=0.5, entry=55_000.0)],
+            open_orders=[],
+        )
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(position=0.5, entry_price=50_000.0,
+                               exchange_snapshot=snap, price_threshold=0.001)
+        result = trader._do_reconcile()
+        assert result["ok"] is False
+        types = [d["type"] for d in result["diffs"]]
+        assert "price_drift" in types
+
+    def test_open_orders_mismatch(self):
+        """Exchange has 1 open order, local has 0."""
+        ex = _make_exchange(
+            positions=[],
+            open_orders=[_ccxt_order()],
+        )
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(position=0.0, exchange_snapshot=snap)
+        result = trader._do_reconcile()
+        assert result["ok"] is False
+        types = [d["type"] for d in result["diffs"]]
+        assert "open_orders_mismatch" in types
+
+    def test_snapshot_error_returns_ok(self):
+        """If snapshot fetch throws, treat as no mismatch (conservative)."""
+        snap = MagicMock()
+        snap.snapshot.side_effect = RuntimeError("network error")
+        trader = _make_trader(position=0.5, entry_price=50_000.0,
+                               exchange_snapshot=snap)
+        result = trader._do_reconcile()
+        assert result["ok"] is True
+
+    def test_audit_logger_called(self):
+        """Each reconcile logs to audit_logger."""
+        ex = _make_exchange(positions=[], open_orders=[])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(exchange_snapshot=snap)
+        audit = MagicMock()
+        trader.audit_logger = audit
+        trader._do_reconcile()
+        audit.log_risk_event.assert_called_once()
+        call_kwargs = audit.log_risk_event.call_args[0][0]
+        assert call_kwargs["type"] == "reconcile"
+
+
+class TestHandleMismatch:
+    def test_halt_triggers_shutdown(self):
+        trader = _make_trader(on_mismatch="halt")
+        trader._trigger_shutdown = MagicMock()
+        trader._handle_mismatch([{"type": "qty_mismatch"}], context="boot")
+        trader._trigger_shutdown.assert_called_once()
+        assert "reconcile_halt" in trader._trigger_shutdown.call_args[0][0]
+
+    def test_warn_does_not_shutdown(self):
+        trader = _make_trader(on_mismatch="warn")
+        trader._trigger_shutdown = MagicMock()
+        trader._handle_mismatch([{"type": "qty_mismatch"}], context="boot")
+        trader._trigger_shutdown.assert_not_called()
+
+    def test_ignore_does_not_shutdown(self):
+        trader = _make_trader(on_mismatch="ignore")
+        trader._trigger_shutdown = MagicMock()
+        trader._handle_mismatch([{"type": "qty_mismatch"}], context="periodic")
+        trader._trigger_shutdown.assert_not_called()
+
+    def test_alerter_notified_on_mismatch(self):
+        trader = _make_trader(on_mismatch="warn")
+        alerter = MagicMock()
+        trader.alerter = alerter
+        trader._handle_mismatch([{"type": "qty_mismatch"}])
+        alerter.send_alert.assert_called_once()
+        args = alerter.send_alert.call_args
+        assert args[1]["level"] == "ERROR" or args[0][1] == "ERROR"
+
+
+class TestReconcileOnBoot:
+    def test_no_snapshot_skips(self):
+        """Without exchange_snapshot, reconcile_on_boot is a no-op."""
+        trader = _make_trader(exchange_snapshot=None)
+        trader._do_reconcile = MagicMock()
+        trader._reconcile_on_boot()
+        trader._do_reconcile.assert_not_called()
+
+    def test_ok_reconcile_no_halt(self):
+        """Clean reconcile on boot → trader keeps running."""
+        ex = _make_exchange(positions=[_ccxt_position(qty=0.5)], open_orders=[])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(position=0.5, entry_price=50_000.0,
+                               exchange_snapshot=snap, on_mismatch="halt")
+        trader._trigger_shutdown = MagicMock()
+        trader._reconcile_on_boot()
+        trader._trigger_shutdown.assert_not_called()
+
+    def test_mismatch_on_boot_halts(self):
+        """Qty mismatch on boot with on_mismatch=halt → shutdown triggered."""
+        ex = _make_exchange(
+            positions=[_ccxt_position(qty=0.9)],   # exchange has 0.9
+            open_orders=[],
+        )
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        # Local has 0.0 position — big mismatch
+        trader = _make_trader(position=0.0, exchange_snapshot=snap, on_mismatch="halt")
+        trader._trigger_shutdown = MagicMock()
+        trader._reconcile_on_boot()
+        trader._trigger_shutdown.assert_called_once()
+
+    def test_mismatch_on_boot_warns(self):
+        """Qty mismatch on boot with on_mismatch=warn → no shutdown."""
+        ex = _make_exchange(positions=[_ccxt_position(qty=0.9)], open_orders=[])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(position=0.0, exchange_snapshot=snap, on_mismatch="warn")
+        trader._trigger_shutdown = MagicMock()
+        trader._reconcile_on_boot()
+        trader._trigger_shutdown.assert_not_called()
+
+    def test_timestamp_updated_on_boot(self):
+        """_last_reconcile_at is set after reconcile_on_boot."""
+        ex = _make_exchange(positions=[], open_orders=[])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(exchange_snapshot=snap)
+        assert trader._last_reconcile_at == 0.0
+        trader._reconcile_on_boot()
+        assert trader._last_reconcile_at > 0.0
+
+
+class TestPeriodicReconcile:
+    def test_no_snapshot_skips(self):
+        trader = _make_trader(exchange_snapshot=None)
+        trader._do_reconcile = MagicMock()
+        trader._periodic_reconcile(time.time())
+        trader._do_reconcile.assert_not_called()
+
+    def test_throttled_within_interval(self):
+        """Not enough time elapsed → reconcile not called."""
+        ex = _make_exchange(positions=[], open_orders=[])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(exchange_snapshot=snap, interval_sec=60.0)
+        trader._last_reconcile_at = time.time()   # just ran
+        trader._do_reconcile = MagicMock()
+        trader._periodic_reconcile(time.time())    # too soon
+        trader._do_reconcile.assert_not_called()
+
+    def test_fires_after_interval(self):
+        """Interval elapsed → reconcile fires."""
+        ex = _make_exchange(positions=[], open_orders=[])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(exchange_snapshot=snap, interval_sec=60.0)
+        trader._last_reconcile_at = time.time() - 61.0   # stale
+        trader._do_reconcile = MagicMock(return_value={"ok": True, "diffs": []})
+        trader._periodic_reconcile(time.time())
+        trader._do_reconcile.assert_called_once()
+
+    def test_timestamp_updated_after_periodic(self):
+        ex = _make_exchange(positions=[], open_orders=[])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(exchange_snapshot=snap, interval_sec=60.0)
+        trader._last_reconcile_at = time.time() - 61.0
+        trader._do_reconcile = MagicMock(return_value={"ok": True, "diffs": []})
+        before = time.time()
+        trader._periodic_reconcile(before + 1)
+        assert trader._last_reconcile_at >= before
+
+    def test_mismatch_during_periodic_warns(self):
+        """Mismatch detected during periodic reconcile with on_mismatch=warn."""
+        ex = _make_exchange(positions=[_ccxt_position(qty=0.5)], open_orders=[])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(position=0.0, exchange_snapshot=snap, on_mismatch="warn")
+        trader._last_reconcile_at = time.time() - 61.0
+        trader._trigger_shutdown = MagicMock()
+        trader._periodic_reconcile(time.time())
+        trader._trigger_shutdown.assert_not_called()
+
+    def test_mismatch_during_periodic_halts(self):
+        """Mismatch detected during periodic reconcile with on_mismatch=halt."""
+        ex = _make_exchange(positions=[_ccxt_position(qty=0.5)], open_orders=[])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+        trader = _make_trader(position=0.0, exchange_snapshot=snap, on_mismatch="halt")
+        trader._last_reconcile_at = time.time() - 61.0
+        trader._trigger_shutdown = MagicMock()
+        trader._periodic_reconcile(time.time())
+        trader._trigger_shutdown.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# F10 — Bootstrap: PaperTrader.restore() calls reconcile-on-boot
+# ---------------------------------------------------------------------------
+
+class TestBootstrapRestore:
+    def test_restore_calls_reconcile_on_boot(self):
+        """PaperTrader.restore() calls _reconcile_on_boot after state load."""
+        from deployment.paper_trader import PaperTrader
+        from unittest.mock import patch as _patch
+
+        agent = MagicMock()
+        config = {
+            "paper_trading": {"symbol": "BTC/USDT", "initial_balance": 10_000.0,
+                               "window_size": 5},
+        }
+        # Provide a real snapshot so restore() doesn't return early at "snap is None"
+        snap_state = {
+            "cash": 10_000.0, "equity": 10_000.0, "symbol": "BTC/USDT",
+            "position": 0.0, "entry_price": 0.0, "current_price": 50_000.0,
+            "peak_value": 10_000.0, "step": 5, "orders": [],
+            "portfolio_history": [10_000.0] * 5, "trades": [],
+            "shutdown_triggered": False, "shutdown_reason": "",
+        }
+        state_store = MagicMock()
+        state_store.db_path = ":memory:"
+        state_store.load_latest.return_value = snap_state
+
+        ex = _make_exchange(positions=[], open_orders=[])
+        snap = ExchangeSnapshot(ex, "BTC/USDT")
+
+        with _patch.object(PaperTrader, "_reconcile_on_boot") as mock_boot:
+            PaperTrader.restore(
+                state_store, agent, config,
+                simulation_mode=True,
+                exchange_snapshot=snap,
+            )
+        mock_boot.assert_called_once()
+
+    def test_restore_detects_position_mismatch(self):
+        """restore() with snapshot mismatch → halt triggered (on_mismatch=halt)."""
+        from deployment.paper_trader import PaperTrader, TradingState
+        from deployment.execution.position_tracker import PositionTracker
+
+        agent = MagicMock()
+        config = {
+            "paper_trading": {
+                "symbol": "BTC/USDT",
+                "initial_balance": 10_000.0,
+                "window_size": 5,
+            },
+            "reconciliation": {"on_mismatch": "halt"},
+        }
+
+        # Saved state has 0.5 BTC position
+        snap_state = {
+            "cash": 5_000.0,
+            "equity": 30_000.0,
+            "symbol": "BTC/USDT",
+            "position": 0.5,
+            "entry_price": 50_000.0,
+            "current_price": 50_000.0,
+            "peak_value": 30_000.0,
+            "step": 10,
+            "orders": [],
+            "portfolio_history": [10_000.0] * 10,
+            "trades": [],
+            "shutdown_triggered": False,
+            "shutdown_reason": "",
+        }
+        state_store = MagicMock()
+        state_store.db_path = ":memory:"
+        state_store.load_latest.return_value = snap_state
+
+        # Exchange says 0.0 position → mismatch
+        ex = _make_exchange(positions=[], open_orders=[], balance={"free": {"BTC": 0.0}, "used": {}, "total": {}})
+        exchange_snap = ExchangeSnapshot(ex, "BTC/USDT")
+
+        trader = PaperTrader.restore(
+            state_store, agent, config,
+            simulation_mode=True,
+            exchange_snapshot=exchange_snap,
+        )
+        # The mismatch should have triggered shutdown
+        assert trader.state.shutdown_triggered is True
+        assert "reconcile_halt" in trader.state.shutdown_reason
+
+
+# ---------------------------------------------------------------------------
+# F11 — ClockSync wire in OrderManager.submit_order
+# ---------------------------------------------------------------------------
+
+class TestClockSkewWire:
+    def test_check_called_in_non_paper_mode(self):
+        """ClockSync.check() is called at submit_order time (non-paper, throttle elapsed)."""
+        from deployment.execution.order_manager import OrderManager
+        from deployment.execution.clock_sync import ClockSync
+
+        clock = MagicMock(spec=ClockSync)
+        clock.is_halted = False
+        clock.check.return_value = 0.5
+
+        om = OrderManager(
+            exchange_config={"exchange_mode": "paper"},  # paper so no real exchange
+            paper_mode=True,
+            clock_sync=clock,
+        )
+        # Force non-paper mode flag to exercise the check path
+        om.paper_mode = False
+        om._last_clock_check_at = 0.0   # expired
+        om._clock_check_interval = 0.0
+
+        try:
+            om.submit_order("buy", 0.01, current_price=50_000.0)
+        except Exception:
+            pass  # execution may fail in mock; we only care about check() call
+
+        clock.check.assert_called()
+
+    def test_check_throttled_within_interval(self):
+        """ClockSync.check() is NOT called if interval hasn't elapsed."""
+        from deployment.execution.order_manager import OrderManager
+        from deployment.execution.clock_sync import ClockSync
+        import time as _time
+
+        clock = MagicMock(spec=ClockSync)
+        clock.is_halted = False
+
+        om = OrderManager(paper_mode=True, clock_sync=clock)
+        om.paper_mode = False
+        om._last_clock_check_at = _time.monotonic()   # just checked
+        om._clock_check_interval = 999.0              # very long
+
+        try:
+            om.submit_order("buy", 0.01, current_price=50_000.0)
+        except Exception:
+            pass
+
+        clock.check.assert_not_called()
+
+    def test_halted_clock_raises(self):
+        """If is_halted is True, submit_order raises RuntimeError."""
+        from deployment.execution.order_manager import OrderManager
+        from deployment.execution.clock_sync import ClockSync
+
+        clock = MagicMock(spec=ClockSync)
+        clock.is_halted = True
+        clock.check.return_value = 10.0
+
+        # Use paper_mode=True to avoid real CCXT init, then override flags
+        om = OrderManager(paper_mode=True, clock_sync=clock)
+        om.paper_mode = False   # trick the F11 check path only
+        om._last_clock_check_at = 0.0
+        om._clock_check_interval = 0.0
+
+        with pytest.raises(RuntimeError, match="clock skew"):
+            om.submit_order("buy", 0.01, current_price=50_000.0)


### PR DESCRIPTION
## Summary

- **F7** — `deployment/exchange/snapshot.py`: `ExchangeSnapshot` wrapping CCXT `fetch_positions` / `fetch_open_orders` / `fetch_balance`. Best-effort (empty on API error).
- **F8** — `PaperTrader._reconcile_on_boot()`: called from `restore()` after StateStore load. Diffs qty, price drift, open orders. Config: `reconciliation.on_mismatch: halt|warn|ignore`.
- **F9** — `PaperTrader._periodic_reconcile()`: called in `run()` loop, fires every `interval_sec` (default 60s). drift → alerter + optional halt.
- **F10** — `tests/exchange/test_snapshot.py`: 38 tests covering all mismatch scenarios, halt/warn/ignore, throttle, bootstrap restore detection.
- **F11** — `OrderManager.submit_order`: proactively calls `ClockSync.check()` (throttled to 30s) so `is_halted` is actually updated before each order.
- **Bonus** — `data/sources/ccxt_live.py`: `CCXTLiveDataSource` (Week 72 F2 missed deliverable) — fixes pre-existing collection error in `test_ccxt_live_source.py`.

## Test plan

- [x] `tests/exchange/test_snapshot.py` — 38/38 pass
- [x] Full pytest — **2202 passed, 42 skipped, 0 failed**
- [ ] Testnet integration: manual position manipulation → restart → mismatch detected (local-only, no CI credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)