### PR TITLE
Week 76: Pre-Trade Compliance (G6-G10)

### DIFF
--- a/deployment/execution/order_manager.py
+++ b/deployment/execution/order_manager.py
@@ -46,6 +46,7 @@ from deployment.execution.rate_limiter import RateLimiter
 from deployment.execution.fat_finger_guard import FatFingerGuard
 from deployment.execution.circuit_breaker import VolatilityCircuitBreaker
 from deployment.execution.clock_sync import ClockSync
+from risk_management.limits import PreTradeComplianceChecker
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +140,9 @@ class OrderManager:
         F16: FeeModel instance.  If provided, overrides hardcoded 0.1% paper fee.
     alerter : optional
         Trading alerter; used to emit cancel-failure alerts (F14).
+    compliance_checker : PreTradeComplianceChecker, optional
+        G6-G9: pre-trade compliance enforcement (position limits, self-trade
+        prevention, notional caps, wash trade guard).
     """
 
     def __init__(
@@ -152,6 +156,7 @@ class OrderManager:
         clock_sync: Optional[ClockSync] = None,
         fee_model=None,
         alerter=None,
+        compliance_checker: Optional[PreTradeComplianceChecker] = None,
     ) -> None:
         exchange_config = exchange_config or {}
         # F3: exchange_mode ("paper" | "sandbox" | "live") overrides paper_mode bool.
@@ -169,6 +174,8 @@ class OrderManager:
         self._max_retries: int = int(exchange_config.get("max_retries", 3))
         self._fee_model = fee_model
         self._alerter = alerter
+        # G6-G9: pre-trade compliance checker (Week 76)
+        self._compliance_checker: Optional[PreTradeComplianceChecker] = compliance_checker
 
         # S41: correlation threshold (from config or default 0.7)
         self._correlation_threshold: float = float(
@@ -358,6 +365,28 @@ class OrderManager:
                 idempotency_key=idempotency_key,
             )
 
+        # G6-G9: pre-trade compliance (Week 76)
+        if self._compliance_checker is not None:
+            _ref_price = current_price or price or limit_price or 1.0
+            _order_notional = amount * _ref_price
+            _tracker = self._position_tracker
+            _sym_notional = _tracker.position * _ref_price
+            _port_notional = _tracker.portfolio_value
+            _comp_ok, _comp_reason = self._compliance_checker.check_all(
+                symbol=self.symbol,
+                side=side,
+                order_notional=_order_notional,
+                limit_price=limit_price,
+                current_symbol_notional=_sym_notional,
+                current_portfolio_notional=_port_notional,
+            )
+            if not _comp_ok:
+                return self._reject_order(
+                    side, amount, order_type, limit_price,
+                    reason=_comp_reason,
+                    idempotency_key=idempotency_key,
+                )
+
         if amount > self.max_order_size:
             logger.warning(
                 "Order amount %.6f exceeds max_order_size %.6f; clamping.",
@@ -394,6 +423,20 @@ class OrderManager:
         # Audit: order submitted
         if self._audit_logger is not None:
             self._audit_logger.log_order(order)
+
+        # G8+G9: commit notional and timestamp for accepted order
+        if self._compliance_checker is not None:
+            _ref_price = current_price or price or limit_price or 1.0
+            self._compliance_checker.record_order(
+                self.symbol, side, amount * _ref_price
+            )
+            # G7: register pending limit orders so future submits can detect crossing
+            if limit_price is not None and order_type in (
+                "limit", "stop_loss_limit", "take_profit"
+            ):
+                self._compliance_checker.register_open_order(
+                    self.symbol, limit_price, side
+                )
 
         try:
             if self.paper_mode:
@@ -446,12 +489,22 @@ class OrderManager:
             if self.paper_mode:
                 order.status = "cancelled"
                 order.updated_at = datetime.utcnow()
+                # G7: release from self-trade tracking
+                if self._compliance_checker is not None and order.limit_price is not None:
+                    self._compliance_checker.deregister_open_order(
+                        self.symbol, order.limit_price
+                    )
                 return True
         try:
             self.rate_limiter.acquire()
             self._exchange.cancel_order(order.exchange_order_id, self.symbol)
             order.status = "cancelled"
             order.updated_at = datetime.utcnow()
+            # G7: release from self-trade tracking
+            if self._compliance_checker is not None and order.limit_price is not None:
+                self._compliance_checker.deregister_open_order(
+                    self.symbol, order.limit_price
+                )
             return True
         except Exception as e:
             logger.error("Failed to cancel order %s: %s", order_id, e)
@@ -808,6 +861,11 @@ class OrderManager:
         else:
             order.status = "filled"
             order.filled_at = datetime.utcnow()   # S52
+            # G7: release filled limit order from self-trade tracking
+            if self._compliance_checker is not None and order.limit_price is not None:
+                self._compliance_checker.deregister_open_order(
+                    self.symbol, order.limit_price
+                )
         order.updated_at = datetime.utcnow()
 
     def _check_pending_orders(self, price: float) -> None:

--- a/risk_management/limits.py
+++ b/risk_management/limits.py
@@ -1,0 +1,278 @@
+"""Pre-trade compliance enforcement.
+
+Week 76 (Track G — Governance & Go-Live Gate):
+  G6 — Position limits per symbol / portfolio
+  G7 — Self-trade prevention
+  G8 — Notional cap per unit time (hourly / daily)
+  G9 — Wash trade guard (same symbol + direction cooldown)
+
+All ``check_*`` methods return ``(allowed: bool, reason: str)``.
+``reason`` is an empty string when ``allowed`` is True.
+
+Usage
+-----
+checker = PreTradeComplianceChecker(ComplianceConfig(
+    per_symbol_notional_max=50_000,
+    hourly_notional_cap=200_000,
+    wash_trade_cooldown_sec=5.0,
+))
+ok, reason = checker.check_all(
+    symbol="BTC/USDT", side="buy", order_notional=1_000,
+    limit_price=None,
+)
+if not ok:
+    reject_order(reason)
+else:
+    checker.record_order("BTC/USDT", "buy", notional=1_000)
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+
+@dataclass
+class ComplianceConfig:
+    """Configuration for pre-trade compliance checks.
+
+    All monetary limits are in the same currency unit as order notional
+    (typically quote currency, e.g. USD).
+    """
+
+    # G6: position limits
+    per_symbol_notional_max: float = float("inf")
+    """Maximum allowed open notional per symbol after this order."""
+
+    portfolio_notional_max: float = float("inf")
+    """Maximum allowed total portfolio notional after this order."""
+
+    leverage_max: float = float("inf")
+    """Maximum leverage multiple (order_notional / portfolio_equity)."""
+
+    # G8: notional caps per unit time
+    hourly_notional_cap: float = float("inf")
+    """Maximum total accepted order notional in any rolling 60-minute window."""
+
+    daily_notional_cap: float = float("inf")
+    """Maximum total accepted order notional in any rolling 24-hour window."""
+
+    # G9: wash trade cooldown
+    wash_trade_cooldown_sec: float = 0.0
+    """Minimum seconds between two same-direction orders on the same symbol.
+    Set to 0 to disable the guard."""
+
+    # G7: self-trade prevention
+    self_trade_prevention: bool = True
+    """When True, reject orders that would immediately cross an open resting order."""
+
+
+class PreTradeComplianceChecker:
+    """Thread-safe pre-trade compliance enforcement (G6-G9).
+
+    Instances are meant to be shared across threads (e.g. passed to
+    ``OrderManager``). All public methods are guarded by a single lock.
+    """
+
+    def __init__(self, config: Optional[ComplianceConfig] = None) -> None:
+        self._cfg = config or ComplianceConfig()
+        self._lock = threading.Lock()
+
+        # G8: sliding-window notional accounting — each entry: (unix_ts, notional)
+        self._hourly_window: deque = deque()
+        self._daily_window: deque = deque()
+
+        # G9: per (symbol, side) → unix timestamp of last accepted order
+        self._wash_guard: Dict[str, Dict[str, float]] = {}
+
+        # G7: open resting orders: symbol → {rounded_price: side}
+        self._open_orders: Dict[str, Dict[float, str]] = {}
+
+    # ------------------------------------------------------------------
+    # G6: Position limits
+    # ------------------------------------------------------------------
+
+    def check_position_limits(
+        self,
+        symbol: str,
+        order_notional: float,
+        current_symbol_notional: float = 0.0,
+        current_portfolio_notional: float = 0.0,
+        leverage: float = 1.0,
+    ) -> Tuple[bool, str]:
+        """Enforce per-symbol notional, portfolio notional, and leverage limits."""
+        cfg = self._cfg
+
+        projected_symbol = current_symbol_notional + order_notional
+        if projected_symbol > cfg.per_symbol_notional_max:
+            return False, (
+                f"position_limit:per_symbol: {symbol} would reach "
+                f"{projected_symbol:.2f} > max {cfg.per_symbol_notional_max:.2f}"
+            )
+
+        projected_portfolio = current_portfolio_notional + order_notional
+        if projected_portfolio > cfg.portfolio_notional_max:
+            return False, (
+                f"position_limit:portfolio: would reach "
+                f"{projected_portfolio:.2f} > max {cfg.portfolio_notional_max:.2f}"
+            )
+
+        if leverage > cfg.leverage_max:
+            return False, (
+                f"position_limit:leverage: {leverage:.3f}x > max {cfg.leverage_max:.3f}x"
+            )
+
+        return True, ""
+
+    # ------------------------------------------------------------------
+    # G7: Self-trade prevention
+    # ------------------------------------------------------------------
+
+    def register_open_order(self, symbol: str, price: float, side: str) -> None:
+        """Register a resting limit order so future checks can detect crossing."""
+        if not self._cfg.self_trade_prevention:
+            return
+        with self._lock:
+            self._open_orders.setdefault(symbol, {})[round(price, 8)] = side
+
+    def deregister_open_order(self, symbol: str, price: float) -> None:
+        """Remove a filled or cancelled order from self-trade tracking."""
+        with self._lock:
+            self._open_orders.get(symbol, {}).pop(round(price, 8), None)
+
+    def check_self_trade(
+        self, symbol: str, price: float, side: str
+    ) -> Tuple[bool, str]:
+        """Reject if a resting order at the same price sits on the opposite side."""
+        if not self._cfg.self_trade_prevention:
+            return True, ""
+        opposite = "sell" if side == "buy" else "buy"
+        with self._lock:
+            existing_side = self._open_orders.get(symbol, {}).get(round(price, 8))
+        if existing_side == opposite:
+            return False, (
+                f"self_trade: open {opposite} at {price} would cross new {side} on {symbol}"
+            )
+        return True, ""
+
+    # ------------------------------------------------------------------
+    # G8: Notional cap per unit time
+    # ------------------------------------------------------------------
+
+    def check_notional_cap(self, order_notional: float) -> Tuple[bool, str]:
+        """Reject if adding this order would breach the rolling hourly or daily cap."""
+        cfg = self._cfg
+        now = time.time()
+
+        with self._lock:
+            # Evict entries that have fallen outside each window
+            hour_cutoff = now - 3600.0
+            day_cutoff = now - 86400.0
+            while self._hourly_window and self._hourly_window[0][0] < hour_cutoff:
+                self._hourly_window.popleft()
+            while self._daily_window and self._daily_window[0][0] < day_cutoff:
+                self._daily_window.popleft()
+            hourly_used = sum(n for _, n in self._hourly_window)
+            daily_used = sum(n for _, n in self._daily_window)
+
+        if hourly_used + order_notional > cfg.hourly_notional_cap:
+            return False, (
+                f"notional_cap:hourly: {hourly_used + order_notional:.2f} "
+                f"> cap {cfg.hourly_notional_cap:.2f}"
+            )
+
+        if daily_used + order_notional > cfg.daily_notional_cap:
+            return False, (
+                f"notional_cap:daily: {daily_used + order_notional:.2f} "
+                f"> cap {cfg.daily_notional_cap:.2f}"
+            )
+
+        return True, ""
+
+    def _record_notional(self, notional: float) -> None:
+        """Commit a notional amount into the sliding windows after order acceptance."""
+        now = time.time()
+        with self._lock:
+            self._hourly_window.append((now, notional))
+            self._daily_window.append((now, notional))
+
+    # ------------------------------------------------------------------
+    # G9: Wash trade guard
+    # ------------------------------------------------------------------
+
+    def check_wash_trade(self, symbol: str, side: str) -> Tuple[bool, str]:
+        """Reject if the same symbol+direction was accepted within the cooldown window."""
+        cooldown = self._cfg.wash_trade_cooldown_sec
+        if cooldown <= 0.0:
+            return True, ""
+        now = time.time()
+        with self._lock:
+            last_ts = self._wash_guard.get(symbol, {}).get(side, 0.0)
+        elapsed = now - last_ts
+        if elapsed < cooldown:
+            return False, (
+                f"wash_trade: {side} {symbol} last seen {elapsed:.3f}s ago "
+                f"< cooldown {cooldown:.1f}s"
+            )
+        return True, ""
+
+    def _record_order_timestamp(self, symbol: str, side: str) -> None:
+        """Stamp the current time as the last accepted order for this symbol+side."""
+        if self._cfg.wash_trade_cooldown_sec <= 0.0:
+            return
+        now = time.time()
+        with self._lock:
+            self._wash_guard.setdefault(symbol, {})[side] = now
+
+    # ------------------------------------------------------------------
+    # Combined API
+    # ------------------------------------------------------------------
+
+    def check_all(
+        self,
+        symbol: str,
+        side: str,
+        order_notional: float,
+        limit_price: Optional[float] = None,
+        current_symbol_notional: float = 0.0,
+        current_portfolio_notional: float = 0.0,
+        leverage: float = 1.0,
+    ) -> Tuple[bool, str]:
+        """Run G6 → G7 → G8 → G9 in sequence.
+
+        Returns the first failure as ``(False, reason)`` or ``(True, "")`` when
+        all checks pass.
+        """
+        ok, reason = self.check_position_limits(
+            symbol, order_notional,
+            current_symbol_notional, current_portfolio_notional, leverage,
+        )
+        if not ok:
+            return ok, reason
+
+        if limit_price is not None:
+            ok, reason = self.check_self_trade(symbol, limit_price, side)
+            if not ok:
+                return ok, reason
+
+        ok, reason = self.check_notional_cap(order_notional)
+        if not ok:
+            return ok, reason
+
+        ok, reason = self.check_wash_trade(symbol, side)
+        if not ok:
+            return ok, reason
+
+        return True, ""
+
+    def record_order(self, symbol: str, side: str, notional: float) -> None:
+        """Commit state updates after a compliant order is accepted.
+
+        Must be called exactly once per accepted order so that G8 and G9
+        accumulators stay accurate.
+        """
+        self._record_notional(notional)
+        self._record_order_timestamp(symbol, side)

--- a/tests/deployment/test_pre_trade_compliance.py
+++ b/tests/deployment/test_pre_trade_compliance.py
@@ -1,0 +1,455 @@
+"""
+Week 76 (G6-G10): Pre-Trade Compliance Tests.
+
+Coverage:
+  G6  — Position limits: per-symbol notional, portfolio notional, leverage cap
+  G7  — Self-trade prevention (resting order cross detection)
+  G8  — Notional cap per unit time (hourly / daily rolling windows)
+  G9  — Wash trade guard (same-direction cooldown)
+  G10 — E2E: multiple guards active simultaneously, audit completeness
+
+완료 조건:
+  - 각 compliance rule에 대응 테스트 존재.
+  - 거부 시 audit 완전 (order_rejected risk_event 포함).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, List
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from deployment.execution.order_manager import OrderManager
+from risk_management.limits import ComplianceConfig, PreTradeComplianceChecker
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_checker(**kwargs) -> PreTradeComplianceChecker:
+    cfg = ComplianceConfig(**kwargs)
+    return PreTradeComplianceChecker(cfg)
+
+
+def make_manager(compliance_checker=None, **cfg_overrides) -> OrderManager:
+    cfg = {"initial_cash": 100_000.0, "max_order_size": 100.0}
+    cfg.update(cfg_overrides)
+    m = OrderManager(
+        exchange_config=cfg,
+        paper_mode=True,
+        compliance_checker=compliance_checker,
+    )
+    m.update_paper_price(1_000.0)
+    return m
+
+
+def rejected_order_ids(manager: OrderManager) -> List[str]:
+    """Return order IDs whose status is 'failed'."""
+    with manager._lock:
+        return [oid for oid, o in manager._orders.items() if o.status == "failed"]
+
+
+# ---------------------------------------------------------------------------
+# G6: Position limits — unit tests
+# ---------------------------------------------------------------------------
+
+class TestPositionLimitsUnit:
+    def test_per_symbol_notional_passes_below_max(self):
+        checker = make_checker(per_symbol_notional_max=10_000)
+        ok, reason = checker.check_position_limits(
+            "BTC/USDT", order_notional=5_000, current_symbol_notional=0
+        )
+        assert ok
+        assert reason == ""
+
+    def test_per_symbol_notional_rejects_at_max(self):
+        checker = make_checker(per_symbol_notional_max=10_000)
+        ok, reason = checker.check_position_limits(
+            "BTC/USDT", order_notional=5_001, current_symbol_notional=5_000
+        )
+        assert not ok
+        assert "per_symbol" in reason
+        assert "BTC/USDT" in reason
+
+    def test_portfolio_notional_passes_below_max(self):
+        checker = make_checker(portfolio_notional_max=50_000)
+        ok, reason = checker.check_position_limits(
+            "BTC/USDT", order_notional=10_000, current_portfolio_notional=39_999
+        )
+        assert ok
+
+    def test_portfolio_notional_rejects_at_max(self):
+        checker = make_checker(portfolio_notional_max=50_000)
+        ok, reason = checker.check_position_limits(
+            "BTC/USDT", order_notional=1_000, current_portfolio_notional=50_000
+        )
+        assert not ok
+        assert "portfolio" in reason
+
+    def test_leverage_cap_passes_below(self):
+        checker = make_checker(leverage_max=3.0)
+        ok, _ = checker.check_position_limits(
+            "BTC/USDT", order_notional=1_000, leverage=2.9
+        )
+        assert ok
+
+    def test_leverage_cap_rejects_above(self):
+        checker = make_checker(leverage_max=3.0)
+        ok, reason = checker.check_position_limits(
+            "BTC/USDT", order_notional=1_000, leverage=3.1
+        )
+        assert not ok
+        assert "leverage" in reason
+
+    def test_defaults_allow_everything(self):
+        checker = PreTradeComplianceChecker()  # all limits = inf
+        ok, _ = checker.check_position_limits(
+            "BTC/USDT", order_notional=1e15, current_symbol_notional=1e15, leverage=1000
+        )
+        assert ok
+
+
+class TestPositionLimitsIntegration:
+    def test_order_rejected_on_symbol_notional_breach(self):
+        """OrderManager rejects when position would exceed per_symbol_notional_max."""
+        checker = make_checker(per_symbol_notional_max=500)
+        m = make_manager(compliance_checker=checker)
+        # First buy: 0.3 BTC @ 1000 = 300 notional (OK)
+        oid1 = m.submit_order("buy", 0.3, current_price=1_000.0)
+        assert m.check_order(oid1) == "filled"
+        # Second buy: would push to 600 notional (FAIL)
+        oid2 = m.submit_order("buy", 0.3, current_price=1_000.0)
+        assert m.check_order(oid2) == "failed"
+
+    def test_rejected_order_logged_to_audit(self):
+        audit = MagicMock()
+        checker = make_checker(per_symbol_notional_max=100)
+        m = make_manager(compliance_checker=checker)
+        m._audit_logger = audit
+        m.submit_order("buy", 0.2, current_price=1_000.0)  # 200 > 100: rejected
+        risk_calls = [
+            c for c in audit.log_risk_event.call_args_list
+        ]
+        assert len(risk_calls) >= 1
+        last_event = risk_calls[-1].args[0]
+        assert last_event["type"] == "order_rejected"
+        assert "position_limit" in last_event["reason"]
+
+
+# ---------------------------------------------------------------------------
+# G7: Self-trade prevention — unit tests
+# ---------------------------------------------------------------------------
+
+class TestSelfTradeUnit:
+    def test_no_cross_when_no_open_orders(self):
+        checker = make_checker(self_trade_prevention=True)
+        ok, _ = checker.check_self_trade("BTC/USDT", price=1_000.0, side="buy")
+        assert ok
+
+    def test_cross_detected_opposite_side(self):
+        checker = make_checker(self_trade_prevention=True)
+        checker.register_open_order("BTC/USDT", price=1_000.0, side="sell")
+        ok, reason = checker.check_self_trade("BTC/USDT", price=1_000.0, side="buy")
+        assert not ok
+        assert "self_trade" in reason
+
+    def test_same_side_not_a_cross(self):
+        checker = make_checker(self_trade_prevention=True)
+        checker.register_open_order("BTC/USDT", price=1_000.0, side="buy")
+        ok, _ = checker.check_self_trade("BTC/USDT", price=1_000.0, side="buy")
+        assert ok
+
+    def test_different_price_not_a_cross(self):
+        checker = make_checker(self_trade_prevention=True)
+        checker.register_open_order("BTC/USDT", price=1_000.0, side="sell")
+        ok, _ = checker.check_self_trade("BTC/USDT", price=999.0, side="buy")
+        assert ok
+
+    def test_deregister_clears_open_order(self):
+        checker = make_checker(self_trade_prevention=True)
+        checker.register_open_order("BTC/USDT", price=1_000.0, side="sell")
+        checker.deregister_open_order("BTC/USDT", price=1_000.0)
+        ok, _ = checker.check_self_trade("BTC/USDT", price=1_000.0, side="buy")
+        assert ok
+
+    def test_disabled_allows_cross(self):
+        checker = make_checker(self_trade_prevention=False)
+        checker.register_open_order("BTC/USDT", price=1_000.0, side="sell")
+        ok, _ = checker.check_self_trade("BTC/USDT", price=1_000.0, side="buy")
+        assert ok
+
+
+class TestSelfTradeIntegration:
+    def test_limit_order_registered_as_open(self):
+        checker = make_checker(self_trade_prevention=True)
+        m = make_manager(compliance_checker=checker)
+        # Buy 1 BTC first so we have inventory to sell
+        m.submit_order("buy", 1.0, current_price=1_000.0)
+        # Place a pending limit sell at 2000; stays pending because market is 1000 < 2000
+        oid_sell = m.submit_order(
+            "sell", 0.5, order_type="limit", limit_price=2_000.0, current_price=1_000.0
+        )
+        assert m.check_order(oid_sell) == "pending"
+        # Now try to buy at the same limit price — should be rejected (self-trade cross)
+        oid_buy = m.submit_order(
+            "buy", 0.5, order_type="limit", limit_price=2_000.0, current_price=1_000.0
+        )
+        assert m.check_order(oid_buy) == "failed"
+
+    def test_cancel_deregisters_open_order(self):
+        checker = make_checker(self_trade_prevention=True)
+        m = make_manager(compliance_checker=checker)
+        m.submit_order("buy", 1.0, current_price=1_000.0)
+        oid_sell = m.submit_order(
+            "sell", 0.5, order_type="limit", limit_price=2_000.0, current_price=1_000.0
+        )
+        assert m.check_order(oid_sell) == "pending"
+        m.cancel_order(oid_sell)
+        # After cancel, crossing buy should be accepted
+        oid_buy = m.submit_order(
+            "buy", 0.1, order_type="limit", limit_price=2_000.0, current_price=1_000.0
+        )
+        assert m.check_order(oid_buy) != "failed"
+
+
+# ---------------------------------------------------------------------------
+# G8: Notional cap — unit tests
+# ---------------------------------------------------------------------------
+
+class TestNotionalCapUnit:
+    def test_first_order_passes(self):
+        checker = make_checker(hourly_notional_cap=10_000)
+        ok, _ = checker.check_notional_cap(5_000)
+        assert ok
+
+    def test_exceeds_hourly_cap(self):
+        checker = make_checker(hourly_notional_cap=10_000)
+        checker.record_order("X", "buy", notional=8_000)
+        ok, reason = checker.check_notional_cap(3_000)
+        assert not ok
+        assert "hourly" in reason
+
+    def test_exceeds_daily_cap(self):
+        checker = make_checker(daily_notional_cap=20_000, hourly_notional_cap=float("inf"))
+        for _ in range(4):
+            checker.record_order("X", "buy", notional=5_000)
+        ok, reason = checker.check_notional_cap(1)
+        assert not ok
+        assert "daily" in reason
+
+    def test_hourly_window_evicts_old_entries(self):
+        checker = make_checker(hourly_notional_cap=10_000)
+        # Inject a stale entry older than 1 hour
+        with checker._lock:
+            checker._hourly_window.append((time.time() - 3700, 9_000))
+        # Current order should now pass since old entry is expired
+        ok, _ = checker.check_notional_cap(9_999)
+        assert ok
+
+    def test_defaults_allow_any_notional(self):
+        checker = PreTradeComplianceChecker()
+        ok, _ = checker.check_notional_cap(1e15)
+        assert ok
+
+
+class TestNotionalCapIntegration:
+    def test_order_rejected_when_hourly_cap_breached(self):
+        checker = make_checker(hourly_notional_cap=1_000)
+        m = make_manager(compliance_checker=checker)
+        # First order: 0.8 * 1000 = 800 (OK, fits under 1000 cap)
+        oid1 = m.submit_order("buy", 0.8, current_price=1_000.0)
+        assert m.check_order(oid1) == "filled"
+        # Second order: would push to 1200 (FAIL)
+        oid2 = m.submit_order("buy", 0.4, current_price=1_000.0)
+        assert m.check_order(oid2) == "failed"
+
+    def test_audit_contains_notional_cap_reason(self):
+        audit = MagicMock()
+        checker = make_checker(hourly_notional_cap=500)
+        m = make_manager(compliance_checker=checker)
+        m._audit_logger = audit
+        m.submit_order("buy", 0.6, current_price=1_000.0)  # 600 > 500: rejected
+        risk_calls = audit.log_risk_event.call_args_list
+        assert any(
+            "notional_cap" in c.args[0]["reason"]
+            for c in risk_calls
+        )
+
+
+# ---------------------------------------------------------------------------
+# G9: Wash trade guard — unit tests
+# ---------------------------------------------------------------------------
+
+class TestWashTradeUnit:
+    def test_first_order_passes(self):
+        checker = make_checker(wash_trade_cooldown_sec=5.0)
+        ok, _ = checker.check_wash_trade("BTC/USDT", "buy")
+        assert ok
+
+    def test_second_order_within_cooldown_rejected(self):
+        checker = make_checker(wash_trade_cooldown_sec=5.0)
+        checker.record_order("BTC/USDT", "buy", notional=100)
+        ok, reason = checker.check_wash_trade("BTC/USDT", "buy")
+        assert not ok
+        assert "wash_trade" in reason
+
+    def test_opposite_side_not_blocked(self):
+        checker = make_checker(wash_trade_cooldown_sec=5.0)
+        checker.record_order("BTC/USDT", "buy", notional=100)
+        ok, _ = checker.check_wash_trade("BTC/USDT", "sell")
+        assert ok
+
+    def test_different_symbol_not_blocked(self):
+        checker = make_checker(wash_trade_cooldown_sec=5.0)
+        checker.record_order("BTC/USDT", "buy", notional=100)
+        ok, _ = checker.check_wash_trade("ETH/USDT", "buy")
+        assert ok
+
+    def test_order_passes_after_cooldown_expires(self):
+        checker = make_checker(wash_trade_cooldown_sec=0.05)  # 50ms
+        checker.record_order("BTC/USDT", "buy", notional=100)
+        time.sleep(0.06)
+        ok, _ = checker.check_wash_trade("BTC/USDT", "buy")
+        assert ok
+
+    def test_disabled_cooldown_always_passes(self):
+        checker = make_checker(wash_trade_cooldown_sec=0.0)
+        checker.record_order("BTC/USDT", "buy", notional=100)
+        ok, _ = checker.check_wash_trade("BTC/USDT", "buy")
+        assert ok
+
+
+class TestWashTradeIntegration:
+    def test_rapid_same_direction_orders_blocked(self):
+        checker = make_checker(wash_trade_cooldown_sec=60.0)
+        m = make_manager(compliance_checker=checker)
+        oid1 = m.submit_order("buy", 0.1, current_price=1_000.0)
+        assert m.check_order(oid1) == "filled"
+        oid2 = m.submit_order("buy", 0.1, current_price=1_000.0)
+        assert m.check_order(oid2) == "failed"
+
+    def test_opposite_direction_not_blocked(self):
+        checker = make_checker(wash_trade_cooldown_sec=60.0)
+        m = make_manager(compliance_checker=checker)
+        m.submit_order("buy", 1.0, current_price=1_000.0)
+        # Sell should not be blocked by wash trade guard (different direction)
+        oid_sell = m.submit_order("sell", 0.5, current_price=1_000.0)
+        assert m.check_order(oid_sell) == "filled"
+
+
+# ---------------------------------------------------------------------------
+# G10: E2E — multiple guards + audit completeness
+# ---------------------------------------------------------------------------
+
+class TestComplianceE2E:
+    def test_all_guards_can_fire_in_sequence(self):
+        """Each guard fires in turn across separate scenarios."""
+        # G6 fires
+        checker_g6 = make_checker(per_symbol_notional_max=100)
+        m_g6 = make_manager(compliance_checker=checker_g6)
+        oid = m_g6.submit_order("buy", 0.2, current_price=1_000.0)  # 200 > 100
+        assert m_g6.check_order(oid) == "failed"
+
+        # G8 fires
+        checker_g8 = make_checker(hourly_notional_cap=100)
+        m_g8 = make_manager(compliance_checker=checker_g8)
+        oid = m_g8.submit_order("buy", 0.2, current_price=1_000.0)  # 200 > 100
+        assert m_g8.check_order(oid) == "failed"
+
+        # G9 fires
+        checker_g9 = make_checker(wash_trade_cooldown_sec=60.0)
+        m_g9 = make_manager(compliance_checker=checker_g9)
+        m_g9.submit_order("buy", 0.01, current_price=1_000.0)
+        oid = m_g9.submit_order("buy", 0.01, current_price=1_000.0)
+        assert m_g9.check_order(oid) == "failed"
+
+    def test_all_rejected_orders_have_audit_risk_events(self):
+        """Every compliance rejection must produce an audit risk event."""
+        audit = MagicMock()
+        scenarios = [
+            # (config_kwargs, buy_amount)
+            ({"per_symbol_notional_max": 100}, 0.2),        # G6
+            ({"hourly_notional_cap": 100}, 0.2),            # G8
+        ]
+        for config_kwargs, buy_amount in scenarios:
+            audit.reset_mock()
+            checker = make_checker(**config_kwargs)
+            m = make_manager(compliance_checker=checker)
+            m._audit_logger = audit
+            m.submit_order("buy", buy_amount, current_price=1_000.0)
+            events = [c.args[0] for c in audit.log_risk_event.call_args_list]
+            assert any(e["type"] == "order_rejected" for e in events), (
+                f"No order_rejected audit event for config {config_kwargs}"
+            )
+
+    def test_multiple_guards_active_simultaneously(self):
+        """When multiple guards are configured, the first one fires correctly."""
+        checker = make_checker(
+            per_symbol_notional_max=50_000,  # high — won't fire first
+            hourly_notional_cap=100,         # low — fires first
+            wash_trade_cooldown_sec=60.0,    # also would fire, but hourly wins
+        )
+        m = make_manager(compliance_checker=checker)
+        oid = m.submit_order("buy", 0.2, current_price=1_000.0)  # 200 > 100 cap
+        assert m.check_order(oid) == "failed"
+        order = m.get_order(oid)
+        assert order is not None
+
+    def test_compliant_order_not_rejected(self):
+        """Sanity: order within all limits is accepted."""
+        checker = make_checker(
+            per_symbol_notional_max=100_000,
+            portfolio_notional_max=500_000,
+            hourly_notional_cap=200_000,
+            daily_notional_cap=500_000,
+            wash_trade_cooldown_sec=0.0,
+            self_trade_prevention=True,
+        )
+        m = make_manager(compliance_checker=checker)
+        oid = m.submit_order("buy", 1.0, current_price=1_000.0)
+        assert m.check_order(oid) == "filled"
+
+    def test_no_compliance_checker_passes_all_orders(self):
+        """OrderManager without compliance_checker behaves as before Week 76."""
+        m = make_manager(compliance_checker=None)
+        oid = m.submit_order("buy", 5.0, current_price=1_000.0)
+        assert m.check_order(oid) == "filled"
+
+    def test_thread_safety(self):
+        """Concurrent order submissions under a tight hourly cap are consistent."""
+        checker = make_checker(hourly_notional_cap=5_000)  # only 5 orders of 1000 each
+        m = make_manager(compliance_checker=checker)
+        results: List[str] = []
+        lock = threading.Lock()
+
+        def submit_one():
+            oid = m.submit_order("buy", 1.0, current_price=1_000.0)
+            with lock:
+                results.append(m.check_order(oid))
+
+        threads = [threading.Thread(target=submit_one) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        filled = results.count("filled")
+        failed = results.count("failed")
+        assert filled <= 5, f"Expected ≤5 fills, got {filled}"
+        assert filled + failed == 10
+
+    def test_rejected_order_fields(self):
+        """A rejected order must have status=failed and a non-empty order_id."""
+        checker = make_checker(hourly_notional_cap=100)
+        m = make_manager(compliance_checker=checker)
+        oid = m.submit_order("buy", 0.2, current_price=1_000.0)
+        order = m.get_order(oid)
+        assert order is not None
+        assert order.status == "failed"
+        assert order.order_id == oid
+        assert order.side == "buy"
+        assert order.amount == pytest.approx(0.2)


### PR DESCRIPTION
## Summary

- **G6** — `risk_management/limits.py`: `PreTradeComplianceChecker` with per-symbol notional max, portfolio notional max, leverage cap
- **G7** — Self-trade prevention: resting limit orders are tracked; incoming order at the same price on the opposite side is rejected before execution
- **G8** — Rolling hourly / daily notional cap enforced with sliding-window deques; state committed only after order acceptance
- **G9** — Wash trade guard: configurable cooldown between same-symbol, same-direction orders
- **G10** — 39 tests (unit, integration, E2E, thread-safety); every guard has a rejection scenario; audit `risk_event` presence verified

## Design notes

- `PreTradeComplianceChecker` is fully thread-safe (single `threading.Lock`)
- `OrderManager` takes optional `compliance_checker=None` — fully backward-compatible
- Guards fire in order: G6 → G7 → G8 → G9; first failure short-circuits
- `record_order()` commits notional + timestamp only after all checks pass (no double-counting on reject)
- G7 open-order registry is cleaned up on `cancel_order()` and on `_execute_paper_order()` fill

## Test plan
- [x] `pytest tests/deployment/test_pre_trade_compliance.py` — 39/39 passed
- [x] `pytest tests/deployment/` — 386/386 passed
- [x] `pytest -q` (full suite) — 2336 passed, 42 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)