### PR TITLE
Week 78: Observability Stack (H1-H5)

### DIFF
--- a/config/monitoring.yaml
+++ b/config/monitoring.yaml
@@ -1,6 +1,7 @@
 # ============================================================
 # config/monitoring.yaml — 모니터링 & 알림 설정
 # Week 63: Config Consolidation
+# Week 78 (H1-H5): Observability Stack — Prometheus, Grafana, Discord, OTel, Sentry
 #
 # base.yaml 위에 deep_merge됨.
 # MetricsExporter, Alerter, Dashboard, Prometheus 설정.
@@ -12,16 +13,20 @@ monitoring:
   # ─ MetricsExporter ──────────────────────────────────────────
   max_history: 10000            # 메모리 내 최대 스냅샷 수
 
-  # ─ Prometheus ───────────────────────────────────────────────
-  use_prometheus: false
-  prometheus_port: 9090
+  # ─ Prometheus (H1) ──────────────────────────────────────────
+  # prometheus_client HTTP server — port 9100
+  # Grafana/Prometheus가 이 엔드포인트를 scrape함
+  use_prometheus: true
+  prometheus_port: 9100
 
   # ─ Dashboard ────────────────────────────────────────────────
   dashboard_enabled: true
   dashboard_port: 8080
 
   # ─ 알림 채널 ────────────────────────────────────────────────
-  alert_channels: ["console"]   # "console" | "telegram" | "webhook"
+  # "console" | "telegram" | "webhook" | "discord"
+  # Discord는 discord_webhook_url 또는 DISCORD_WEBHOOK_URL env var 필요
+  alert_channels: ["console"]
   drawdown_alert_threshold: 0.10
   daily_loss_alert: -500.0
   connection_timeout_seconds: 60.0
@@ -31,8 +36,13 @@ monitoring:
   telegram_token: ""
   telegram_chat_id: ""
 
-  # ─ Webhook ──────────────────────────────────────────────────
+  # ─ Generic Webhook ──────────────────────────────────────────
   webhook_url: ""
+
+  # ─ Discord (H3) ─────────────────────────────────────────────
+  # Discord Incoming Webhook URL
+  # 환경변수 DISCORD_WEBHOOK_URL로도 설정 가능
+  discord_webhook_url: ""
 
   # ─ Drift 감지 (모니터링 레이어) ──────────────────────────────
   use_drift_detection: false
@@ -40,15 +50,24 @@ monitoring:
   drift_window_size: 500
 
   # ─ Feature Drift (S56) ──────────────────────────────────────
-  # When enabled, each feature in the observation vector is monitored
-  # individually.  Alarm fires → audit log + alerter.
   use_feature_drift_detection: false
   feature_drift_method: "adwin"  # "adwin" | "page_hinkley"
 
   # ─ Regime Detection (S57) ────────────────────────────────────
-  # When enabled, RegimeDetector.predict() is called every step using
-  # the current price history window.  Regime changes are logged and
-  # the on_regime_change hook is called.
   use_regime_detection: false
   regime_n_regimes: 3           # number of hidden states
   regime_method: "threshold"    # "hmm" | "threshold" (hmm requires hmmlearn)
+
+  # ─ OpenTelemetry Tracing (H4) ────────────────────────────────
+  # OTel span export. OTEL_EXPORTER_OTLP_ENDPOINT env var 설정 시 OTLP로 전송.
+  # 미설정 시 ConsoleSpanExporter (stdout).
+  otel_enabled: true
+  otel_service_name: "trading-bot"
+  # otel_otlp_endpoint: "http://localhost:4318"  # Jaeger OTLP HTTP
+
+  # ─ Sentry (H5) ──────────────────────────────────────────────
+  # 런타임 예외 자동 수집. SENTRY_DSN env var 또는 아래 설정.
+  # credential/price 데이터는 before_send hook에서 자동 scrubbing.
+  sentry_dsn: ""                # 또는 env var SENTRY_DSN
+  sentry_traces_sample_rate: 0.1
+  sentry_environment: "local"   # "local" | "paper" | "live"

--- a/deployment/monitoring/__init__.py
+++ b/deployment/monitoring/__init__.py
@@ -1,4 +1,16 @@
 """Monitoring and alerting for live/paper trading."""
 from deployment.monitoring.alerter import TradingAlerter
+from deployment.monitoring.metrics_exporter import MetricsExporter, MetricSnapshot
+from deployment.monitoring.tracing import init_tracing, start_span, shutdown_tracing
+from deployment.monitoring.sentry_init import init_sentry, capture_exception
 
-__all__ = ["TradingAlerter"]
+__all__ = [
+    "TradingAlerter",
+    "MetricsExporter",
+    "MetricSnapshot",
+    "init_tracing",
+    "start_span",
+    "shutdown_tracing",
+    "init_sentry",
+    "capture_exception",
+]

--- a/deployment/monitoring/alerter.py
+++ b/deployment/monitoring/alerter.py
@@ -3,33 +3,37 @@ Trading Alerter: condition-based notification dispatcher.
 
 Supported channels:
     - console  : logger.warning (always available, used as fallback)
-    - telegram : sends message via python-telegram-bot (requires token + chat_id)
+    - telegram : sends message via Telegram Bot API
     - webhook  : HTTP POST to a generic endpoint
+    - discord  : HTTP POST to a Discord webhook URL
 
 Triggers:
     - drawdown exceeds threshold (default 10 %)
     - daily P&L below loss limit
     - feature/reward drift detected
     - connection lost for more than N seconds
+    - kill switch activated
+    - audit chain integrity break
+    - runtime error (notify_error)
     - trade executed (optional, verbose mode only)
 
 Usage:
     alerter = TradingAlerter({
-        "alert_channels": ["console", "telegram"],
+        "alert_channels": ["console", "discord"],
         "drawdown_alert_threshold": 0.10,
         "daily_loss_alert": -500,
-        "telegram_token": "...",
-        "telegram_chat_id": "...",
+        "discord_webhook_url": "https://discord.com/api/webhooks/...",
     })
     alerter.check_drawdown(current=9000, peak=10000)
     alerter.check_daily_pnl(pnl=-600)
     alerter.notify_drift(detector="adwin", signal_name="reward")
-    alerter.notify_trade(side="buy", amount=0.05, price=30000.0)
+    alerter.notify_kill_switch()
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import time
 import urllib.request
 import urllib.parse
@@ -39,6 +43,12 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+# Discord embeds colour codes
+_COLOUR_WARNING = 0xFFA500   # orange
+_COLOUR_CRITICAL = 0xFF0000  # red
+_COLOUR_INFO = 0x00B0F4      # blue
+_COLOUR_ERROR = 0xFF0000     # red
 
 
 @dataclass
@@ -63,13 +73,15 @@ class TradingAlerter:
     config : dict
         Alert configuration.
         Keys:
-            alert_channels              – list of channels: ["console"], ["telegram"], ["webhook"]
+            alert_channels              – list of channels: ["console"] | ["telegram"] |
+                                          ["webhook"] | ["discord"]
             drawdown_alert_threshold    – drawdown fraction to trigger alert (default 0.10)
             daily_loss_alert            – daily P&L threshold to trigger alert (default -500)
             connection_timeout_seconds  – seconds of lost connection before alert (default 60)
-            telegram_token              – Telegram bot token (or set TELEGRAM_BOT_TOKEN env var)
-            telegram_chat_id            – Telegram chat id (or set TELEGRAM_CHAT_ID env var)
-            webhook_url                 – HTTP endpoint for webhook alerts
+            telegram_token              – Telegram bot token (or TELEGRAM_BOT_TOKEN env var)
+            telegram_chat_id            – Telegram chat id (or TELEGRAM_CHAT_ID env var)
+            webhook_url                 – HTTP endpoint for generic webhook alerts
+            discord_webhook_url         – Discord webhook URL (or DISCORD_WEBHOOK_URL env var)
             verbose                     – if True, also alert on every trade (default False)
     """
 
@@ -81,7 +93,6 @@ class TradingAlerter:
         self.verbose: bool = bool(config.get("verbose", False))
 
         # Telegram
-        import os
         self._telegram_token: Optional[str] = (
             config.get("telegram_token") or os.environ.get("TELEGRAM_BOT_TOKEN")
         )
@@ -89,14 +100,21 @@ class TradingAlerter:
             str(config.get("telegram_chat_id", "")) or os.environ.get("TELEGRAM_CHAT_ID")
         )
 
-        # Webhook
+        # Generic webhook
         self._webhook_url: Optional[str] = config.get("webhook_url") or None
+
+        # Discord webhook
+        self._discord_url: Optional[str] = (
+            config.get("discord_webhook_url")
+            or os.environ.get("DISCORD_WEBHOOK_URL")
+            or None
+        )
 
         # Connection tracking
         self._last_connection_time: float = time.monotonic()
         self._connection_alert_sent: bool = False
 
-        # Audit log (useful for testing and post-hoc analysis)
+        # Audit log
         self.alert_history: List[AlertRecord] = []
 
         logger.info(
@@ -111,14 +129,9 @@ class TradingAlerter:
     # ------------------------------------------------------------------
 
     def check_drawdown(self, current: float, peak: float) -> bool:
-        """
-        Check if drawdown from peak exceeds the alert threshold.
-
-        Returns True if alert was triggered.
-        """
+        """Alert if drawdown from peak exceeds the threshold. Returns True if fired."""
         if peak <= 0:
             return False
-
         drawdown = (peak - current) / peak
         if drawdown >= self.drawdown_threshold:
             self._dispatch(
@@ -134,11 +147,7 @@ class TradingAlerter:
         return False
 
     def check_daily_pnl(self, pnl: float) -> bool:
-        """
-        Check if daily P&L has dropped below the alert threshold.
-
-        Returns True if alert was triggered.
-        """
+        """Alert if daily P&L is below the loss limit. Returns True if fired."""
         if pnl <= self.daily_loss_limit:
             self._dispatch(
                 level="CRITICAL",
@@ -152,16 +161,7 @@ class TradingAlerter:
         return False
 
     def check_connection_lost(self, seconds_since_last_tick: float) -> bool:
-        """
-        Fire an alert if the data feed has been silent for > connection_timeout seconds.
-
-        Parameters
-        ----------
-        seconds_since_last_tick : float
-            Elapsed seconds since the last received data tick.
-
-        Returns True if alert was triggered.
-        """
+        """Alert if data feed has been silent for > connection_timeout. Returns True if fired."""
         if seconds_since_last_tick > self.connection_timeout:
             self._dispatch(
                 level="CRITICAL",
@@ -188,7 +188,7 @@ class TradingAlerter:
         logger.info("Connection restored; alert state reset.")
 
     def notify_trade(self, side: str, amount: float, price: float, order_id: str = "") -> None:
-        """Optionally alert on trade execution (only in verbose mode)."""
+        """Alert on trade execution (only in verbose mode)."""
         if not self.verbose:
             return
         self._dispatch(
@@ -199,6 +199,28 @@ class TradingAlerter:
                 + (f" (id={order_id})" if order_id else "")
             ),
         )
+
+    def notify_error(self, error: str, context: Optional[str] = None) -> None:
+        """Alert on a runtime error (called from OrderManager and PaperTrader error paths)."""
+        msg = f"Runtime error: {error}"
+        if context:
+            msg += f" | context={context}"
+        self._dispatch(level="ERROR", event="runtime_error", message=msg)
+
+    def notify_kill_switch(self, reason: str = "manual") -> None:
+        """Alert that the kill switch has been activated — highest priority."""
+        self._dispatch(
+            level="CRITICAL",
+            event="kill_switch_activated",
+            message=f"KILL SWITCH ACTIVATED — reason={reason}. All orders cancelled.",
+        )
+
+    def notify_audit_chain_break(self, details: str = "") -> None:
+        """Alert that audit log integrity has been compromised."""
+        msg = "AUDIT CHAIN INTEGRITY BREAK detected — log continuity cannot be guaranteed."
+        if details:
+            msg += f" Details: {details}"
+        self._dispatch(level="CRITICAL", event="audit_chain_break", message=msg)
 
     def send_alert(self, message: str, level: str = "WARNING") -> None:
         """Manually dispatch an alert message."""
@@ -223,6 +245,8 @@ class TradingAlerter:
                 self._send_telegram(full_message)
             elif channel == "webhook":
                 self._send_webhook(event, level, message, timestamp)
+            elif channel == "discord":
+                self._send_discord(event, level, message, timestamp)
             else:
                 logger.warning("Unknown alert channel: %s", channel)
 
@@ -282,3 +306,45 @@ class TradingAlerter:
                     logger.warning("Webhook returned status %s", resp.status)
         except Exception as e:
             logger.error("Webhook alert failed: %s", e)
+
+    def _send_discord(self, event: str, level: str, message: str, timestamp: str) -> None:
+        """Send alert to a Discord channel via incoming webhook."""
+        if not self._discord_url:
+            logger.warning(
+                "Discord alert skipped: discord_webhook_url not configured. "
+                "Set DISCORD_WEBHOOK_URL env var."
+            )
+            return
+
+        colour_map = {
+            "CRITICAL": _COLOUR_CRITICAL,
+            "ERROR": _COLOUR_ERROR,
+            "WARNING": _COLOUR_WARNING,
+            "INFO": _COLOUR_INFO,
+        }
+        colour = colour_map.get(level, _COLOUR_WARNING)
+
+        try:
+            payload = json.dumps({
+                "username": "Trading Bot Alerter",
+                "embeds": [
+                    {
+                        "title": f"[{level}] {event}",
+                        "description": message,
+                        "color": colour,
+                        "footer": {"text": timestamp},
+                    }
+                ],
+            }).encode("utf-8")
+            req = urllib.request.Request(
+                self._discord_url,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                # Discord returns 204 No Content on success
+                if resp.status not in (200, 204):
+                    logger.warning("Discord webhook returned status %s", resp.status)
+        except Exception as e:
+            logger.error("Discord alert failed: %s", e)

--- a/deployment/monitoring/grafana_dashboard.json
+++ b/deployment/monitoring/grafana_dashboard.json
@@ -1,0 +1,684 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source (trading bot metrics on :9100)",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Trading Bot Live Observability — Week 78 H2",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Status",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "text": "RUNNING" }, "1": { "text": "HALTED" } }, "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 3, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_is_halted",
+          "legendFormat": "Halt",
+          "refId": "A"
+        }
+      ],
+      "title": "Trading Status",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "text": "OFF" }, "1": { "text": "ACTIVE" } }, "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "dark-red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 3, "x": 3, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_kill_switch_active",
+          "legendFormat": "Kill Switch",
+          "refId": "A"
+        }
+      ],
+      "title": "Kill Switch",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0 },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 3, "x": 6, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_drift_detected",
+          "legendFormat": "Drift",
+          "refId": "A"
+        }
+      ],
+      "title": "Drift Detected",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null }
+            ]
+          },
+          "unit": "currencyUSD",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 9, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_portfolio_value_usd",
+          "legendFormat": "Portfolio",
+          "refId": "A"
+        }
+      ],
+      "title": "Portfolio Value",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.05 },
+              { "color": "red", "value": 0.10 }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 0.5
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 5, "x": 13, "y": 1 },
+      "id": 5,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_drawdown_pct",
+          "legendFormat": "Drawdown",
+          "refId": "A"
+        }
+      ],
+      "title": "Drawdown %",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 6, "x": 18, "y": 1 },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_trades_total",
+          "legendFormat": "Trades",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_alerts_total",
+          "legendFormat": "Alerts",
+          "refId": "B"
+        }
+      ],
+      "title": "Trades / Alerts Total",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 4 },
+      "id": 101,
+      "title": "P&L Attribution",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "USD",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Market Move" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "#73BF69", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Slippage Cost" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "#F2495C", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Fees" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Net P&L" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "#5794F2", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["last", "mean"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_pnl_market_move_usd",
+          "legendFormat": "Market Move",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_pnl_slippage_cost_usd",
+          "legendFormat": "Slippage Cost",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_pnl_fees_usd",
+          "legendFormat": "Fees",
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_pnl_net_usd",
+          "legendFormat": "Net P&L",
+          "refId": "D"
+        }
+      ],
+      "title": "P&L Attribution Breakdown",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["last"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_rolling_sharpe_ratio",
+          "legendFormat": "Rolling Sharpe",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_rolling_sortino_ratio",
+          "legendFormat": "Rolling Sortino",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_sharpe_ratio",
+          "legendFormat": "Sharpe (all-time)",
+          "refId": "C"
+        }
+      ],
+      "title": "Risk-Adjusted Performance",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "id": 102,
+      "title": "Order Latency",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "ms",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          },
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "p50" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "#73BF69", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "p95" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "p99" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "#F2495C", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 7, "w": 16, "x": 0, "y": 14 },
+      "id": 20,
+      "options": {
+        "legend": { "calcs": ["last", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_order_latency_p50_ms",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_order_latency_p95_ms",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_order_latency_p99_ms",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Order Latency Percentiles (ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "unit": "ms",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 14 },
+      "id": 21,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_order_latency_p99_ms",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p99 (ms)",
+      "type": "gauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 21 },
+      "id": 103,
+      "title": "Risk & Drift",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 22 },
+      "id": 30,
+      "options": {
+        "legend": { "calcs": ["max", "last"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_drawdown_pct",
+          "legendFormat": "Drawdown",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_win_rate",
+          "legendFormat": "Win Rate",
+          "refId": "B"
+        }
+      ],
+      "title": "Drawdown & Win Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 22 },
+      "id": 31,
+      "options": {
+        "legend": { "calcs": ["last", "sum"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_feature_drift_alarms_total",
+          "legendFormat": "Drift Alarms (cumulative)",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_alerts_total",
+          "legendFormat": "Alerts (cumulative)",
+          "refId": "B"
+        }
+      ],
+      "title": "Drift Alarms & Alerts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 29 },
+      "id": 40,
+      "options": {
+        "legend": { "calcs": ["last", "mean", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_portfolio_value_usd",
+          "legendFormat": "Portfolio Value",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_cash_usd",
+          "legendFormat": "Cash",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_unrealised_pnl_usd",
+          "legendFormat": "Unrealised P&L",
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trading_daily_pnl_usd",
+          "legendFormat": "Daily P&L",
+          "refId": "D"
+        }
+      ],
+      "title": "Portfolio History",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "tags": ["trading-bot", "phase7", "week78"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Trading Bot — Live Observability",
+  "uid": "trading-bot-h2",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deployment/monitoring/grafana_provisioning/dashboards/dashboards.yaml
+++ b/deployment/monitoring/grafana_provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: Trading Bot
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deployment/monitoring/grafana_provisioning/datasources/prometheus.yaml
+++ b/deployment/monitoring/grafana_provisioning/datasources/prometheus.yaml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: DS_PROMETHEUS
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      timeInterval: 10s

--- a/deployment/monitoring/metrics_exporter.py
+++ b/deployment/monitoring/metrics_exporter.py
@@ -19,11 +19,22 @@ logger = logging.getLogger(__name__)
 
 # Try prometheus_client, fallback to in-memory
 try:
-    from prometheus_client import Gauge, Counter, Histogram, start_http_server
+    from prometheus_client import (
+        Gauge,
+        Counter,
+        Histogram,
+        start_http_server,
+        REGISTRY,
+    )
     HAS_PROMETHEUS = True
 except ImportError:
     HAS_PROMETHEUS = False
     logger.info("prometheus_client not installed; using in-memory metrics")
+
+# Latency histogram buckets (ms): sub-ms to 5s
+_LATENCY_BUCKETS = (
+    0.5, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000
+)
 
 
 @dataclass
@@ -61,20 +72,21 @@ class MetricSnapshot:
     current_regime: int = -1
     # S56: number of feature drift alarms fired (cumulative)
     feature_drift_alarms: int = 0
+    # Kill switch status (H3/H1 integration)
+    kill_switch_active: bool = False
 
 
 class MetricsExporter:
     """Collect, store, and export trading metrics.
 
     Supports two backends:
-    - prometheus: exposes /metrics endpoint on configurable port
+    - prometheus: exposes /metrics endpoint on configurable port (default 9100)
     - memory: stores snapshots in-memory, queryable via snapshot()/history()
 
-    Usage:
-        exporter = MetricsExporter(config)
-        exporter.update(portfolio_value=10200, cash=5000, ...)
-        latest = exporter.snapshot()
-        all_history = exporter.history()
+    All 30 MetricSnapshot fields are mapped to Prometheus metrics:
+    - Gauge  : portfolio_value, cash, position, p&l, drawdown, ratios, regime, latencies
+    - Counter: num_trades, alerts_fired, feature_drift_alarms (monotonic)
+    - Histogram: order latency (p50/p95/p99 observed directly via observe())
     """
 
     def __init__(self, config: Optional[Dict[str, Any]] = None):
@@ -86,25 +98,188 @@ class MetricsExporter:
 
         # Prometheus backend
         self._use_prometheus = config.get("use_prometheus", False) and HAS_PROMETHEUS
+        self._prom: Dict[str, Any] = {}
         if self._use_prometheus:
-            port = int(config.get("prometheus_port", 9090))
+            port = int(config.get("prometheus_port", 9100))
             self._init_prometheus(port)
 
-    def _init_prometheus(self, port: int):
-        """Register Prometheus gauges and start HTTP server."""
-        self._prom = {
-            "portfolio_value": Gauge("trading_portfolio_value", "Current portfolio value"),
-            "cash": Gauge("trading_cash", "Available cash"),
-            "position": Gauge("trading_position", "Current position size"),
-            "drawdown_pct": Gauge("trading_drawdown_pct", "Current drawdown %"),
-            "daily_pnl": Gauge("trading_daily_pnl", "Daily P&L"),
-            "num_trades": Counter("trading_num_trades_total", "Total trades executed"),
-            "alerts_fired": Counter("trading_alerts_fired_total", "Total alerts fired"),
-            "drift_detected": Gauge("trading_drift_detected", "Drift detection flag"),
-            "is_halted": Gauge("trading_is_halted", "Trading halt flag"),
-        }
+    def _init_prometheus(self, port: int) -> None:
+        """Register Prometheus gauges/counters/histograms and start HTTP server."""
+        # Gauges — portfolio state
+        self._prom["portfolio_value"] = Gauge(
+            "trading_portfolio_value_usd", "Current portfolio value (USD)"
+        )
+        self._prom["cash"] = Gauge(
+            "trading_cash_usd", "Available cash (USD)"
+        )
+        self._prom["position"] = Gauge(
+            "trading_position_size", "Current position size (base asset)"
+        )
+        self._prom["unrealised_pnl"] = Gauge(
+            "trading_unrealised_pnl_usd", "Mark-to-market unrealised P&L (USD)"
+        )
+        self._prom["realised_pnl"] = Gauge(
+            "trading_realised_pnl_usd", "Realised P&L (USD)"
+        )
+        self._prom["daily_pnl"] = Gauge(
+            "trading_daily_pnl_usd", "Daily P&L (USD)"
+        )
+
+        # Gauges — risk
+        self._prom["drawdown_pct"] = Gauge(
+            "trading_drawdown_pct", "Current drawdown fraction (0-1)"
+        )
+        self._prom["current_var"] = Gauge(
+            "trading_var_usd", "Current Value-at-Risk (USD)"
+        )
+        self._prom["is_halted"] = Gauge(
+            "trading_is_halted", "Trading halt flag (1=halted, 0=running)"
+        )
+        self._prom["kill_switch_active"] = Gauge(
+            "trading_kill_switch_active", "Kill switch status (1=active)"
+        )
+
+        # Gauges — performance
+        self._prom["win_rate"] = Gauge(
+            "trading_win_rate", "Win rate fraction (0-1)"
+        )
+        self._prom["sharpe_ratio"] = Gauge(
+            "trading_sharpe_ratio", "Sharpe ratio (annualised)"
+        )
+        self._prom["rolling_sharpe"] = Gauge(
+            "trading_rolling_sharpe_ratio", "Rolling Sharpe ratio (20-step window)"
+        )
+        self._prom["rolling_sortino"] = Gauge(
+            "trading_rolling_sortino_ratio", "Rolling Sortino ratio (20-step window)"
+        )
+
+        # Gauges — P&L attribution
+        self._prom["pnl_market_move"] = Gauge(
+            "trading_pnl_market_move_usd", "P&L from market direction (USD)"
+        )
+        self._prom["pnl_slippage_cost"] = Gauge(
+            "trading_pnl_slippage_cost_usd", "P&L cost from slippage (USD)"
+        )
+        self._prom["pnl_fees"] = Gauge(
+            "trading_pnl_fees_usd", "P&L cost from trading fees (USD)"
+        )
+        self._prom["pnl_net"] = Gauge(
+            "trading_pnl_net_usd", "Net P&L (market_move - slippage - fees, USD)"
+        )
+
+        # Gauges — drift / regime
+        self._prom["drift_detected"] = Gauge(
+            "trading_drift_detected", "Concept drift detected flag (1=yes)"
+        )
+        self._prom["current_regime"] = Gauge(
+            "trading_current_regime",
+            "Market regime (0=low-vol, 1=medium-vol, 2=high-vol, -1=unknown)",
+        )
+
+        # Gauges — latency percentiles (ms)
+        self._prom["latency_p50_ms"] = Gauge(
+            "trading_order_latency_p50_ms", "Order latency p50 (ms)"
+        )
+        self._prom["latency_p95_ms"] = Gauge(
+            "trading_order_latency_p95_ms", "Order latency p95 (ms)"
+        )
+        self._prom["latency_p99_ms"] = Gauge(
+            "trading_order_latency_p99_ms", "Order latency p99 (ms)"
+        )
+
+        # Histogram — raw latency observations (each order submission calls observe())
+        self._prom["order_latency_histogram"] = Histogram(
+            "trading_order_latency_ms",
+            "Order round-trip latency (ms)",
+            buckets=_LATENCY_BUCKETS,
+        )
+
+        # Counters — monotonically increasing
+        self._prom["num_trades"] = Counter(
+            "trading_trades_total", "Total number of trades executed"
+        )
+        self._prom["alerts_fired"] = Counter(
+            "trading_alerts_total", "Total number of alerts dispatched"
+        )
+        self._prom["feature_drift_alarms"] = Counter(
+            "trading_feature_drift_alarms_total",
+            "Cumulative feature drift alarms fired",
+        )
+
         start_http_server(port)
-        logger.info("Prometheus metrics server started on port %d", port)
+        logger.info("Prometheus metrics server started on :%d/metrics", port)
+
+    # ------------------------------------------------------------------
+    # Counter tracking (needed for monotonic-only counters)
+    # ------------------------------------------------------------------
+
+    _prev_trades: int = 0
+    _prev_alerts: int = 0
+    _prev_drift_alarms: int = 0
+
+    def _update_prometheus(self, snap: MetricSnapshot) -> None:
+        """Push all snapshot fields to registered Prometheus metrics."""
+        g = self._prom
+
+        # Portfolio state
+        g["portfolio_value"].set(snap.portfolio_value)
+        g["cash"].set(snap.cash)
+        g["position"].set(snap.position)
+        g["unrealised_pnl"].set(snap.unrealised_pnl)
+        g["realised_pnl"].set(snap.realised_pnl)
+        g["daily_pnl"].set(snap.daily_pnl)
+
+        # Risk
+        g["drawdown_pct"].set(snap.drawdown_pct)
+        g["current_var"].set(snap.current_var)
+        g["is_halted"].set(1.0 if snap.is_halted else 0.0)
+        g["kill_switch_active"].set(1.0 if snap.kill_switch_active else 0.0)
+
+        # Performance
+        g["win_rate"].set(snap.win_rate)
+        g["sharpe_ratio"].set(snap.sharpe_ratio)
+        g["rolling_sharpe"].set(snap.rolling_sharpe)
+        g["rolling_sortino"].set(snap.rolling_sortino)
+
+        # P&L attribution
+        g["pnl_market_move"].set(snap.pnl_market_move)
+        g["pnl_slippage_cost"].set(snap.pnl_slippage_cost)
+        g["pnl_fees"].set(snap.pnl_fees)
+        g["pnl_net"].set(snap.pnl_net)
+
+        # Drift / regime
+        g["drift_detected"].set(1.0 if snap.drift_detected else 0.0)
+        g["current_regime"].set(snap.current_regime)
+
+        # Latency percentile gauges
+        g["latency_p50_ms"].set(snap.latency_p50_ms)
+        g["latency_p95_ms"].set(snap.latency_p95_ms)
+        g["latency_p99_ms"].set(snap.latency_p99_ms)
+
+        # Monotonic counters — only inc() by delta
+        delta_trades = max(0, snap.num_trades - self._prev_trades)
+        if delta_trades:
+            g["num_trades"].inc(delta_trades)
+            self._prev_trades = snap.num_trades
+
+        delta_alerts = max(0, snap.alerts_fired - self._prev_alerts)
+        if delta_alerts:
+            g["alerts_fired"].inc(delta_alerts)
+            self._prev_alerts = snap.alerts_fired
+
+        delta_drift = max(0, snap.feature_drift_alarms - self._prev_drift_alarms)
+        if delta_drift:
+            g["feature_drift_alarms"].inc(delta_drift)
+            self._prev_drift_alarms = snap.feature_drift_alarms
+
+    def observe_order_latency(self, latency_ms: float) -> None:
+        """Record a raw order latency observation in the Prometheus histogram."""
+        if self._use_prometheus and "order_latency_histogram" in self._prom:
+            self._prom["order_latency_histogram"].observe(latency_ms)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def update(self, **kwargs) -> MetricSnapshot:
         """Record a new metric snapshot.
@@ -139,19 +314,13 @@ class MetricsExporter:
             if len(self._history) > self._max_history:
                 self._history = self._history[-self._max_history:]
 
-        # Update Prometheus gauges
         if self._use_prometheus:
-            for key in ("portfolio_value", "cash", "position", "drawdown_pct",
-                        "daily_pnl", "drift_detected", "is_halted"):
-                self._prom[key].set(getattr(snap, key))
+            self._update_prometheus(snap)
 
         return snap
 
     def update_latency(self, p50: float, p95: float, p99: float) -> MetricSnapshot:
-        """Record order latency percentiles (ms) as a metric update.
-
-        Convenience wrapper so callers don't need to know the field names.
-        """
+        """Record order latency percentiles (ms) as a metric update."""
         return self.update(
             latency_p50_ms=float(p50),
             latency_p95_ms=float(p95),
@@ -159,10 +328,7 @@ class MetricsExporter:
         )
 
     def rolling_sharpe(self, window: int = 20, annualize: int = 252) -> float:
-        """Compute rolling Sharpe ratio from the last *window* portfolio-value snapshots.
-
-        Returns 0.0 if insufficient history.
-        """
+        """Compute rolling Sharpe ratio from the last *window* portfolio-value snapshots."""
         snaps = self.history(last_n=window + 1)
         if len(snaps) < 2:
             return 0.0
@@ -180,10 +346,7 @@ class MetricsExporter:
         annualize: int = 252,
         mar: float = 0.0,
     ) -> float:
-        """Compute rolling Sortino ratio from the last *window* portfolio-value snapshots.
-
-        Returns 0.0 if insufficient history.
-        """
+        """Compute rolling Sortino ratio from the last *window* portfolio-value snapshots."""
         snaps = self.history(last_n=window + 1)
         if len(snaps) < 2:
             return 0.0
@@ -192,7 +355,7 @@ class MetricsExporter:
         returns = np.diff(values) / prev
         downside = returns[returns < mar]
         if len(downside) == 0:
-            return float(np.mean(returns) * np.sqrt(annualize))  # no downside
+            return float(np.mean(returns) * np.sqrt(annualize))
         downside_std = float(np.std(downside))
         if downside_std < 1e-10:
             return 0.0
@@ -246,4 +409,6 @@ class MetricsExporter:
             "current_regime": snap.current_regime,
             # S56
             "feature_drift_alarms": snap.feature_drift_alarms,
+            # H1/H3
+            "kill_switch_active": snap.kill_switch_active,
         }

--- a/deployment/monitoring/prometheus.yml
+++ b/deployment/monitoring/prometheus.yml
@@ -1,0 +1,32 @@
+# Prometheus scrape configuration — Week 78 H1
+#
+# The trading bot exposes metrics on :9100/metrics (prometheus_client HTTP server).
+# Prometheus scrapes every 10 seconds.
+#
+# Usage:
+#   docker-compose up prometheus grafana
+#   open http://localhost:9090   # Prometheus UI
+#   open http://localhost:3000   # Grafana (admin / trading_admin)
+
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+  external_labels:
+    service: trading-bot
+
+scrape_configs:
+  # Trading bot metrics (MetricsExporter HTTP server on :9100)
+  - job_name: trading_bot
+    static_configs:
+      - targets:
+          - host.docker.internal:9100   # Docker Desktop (Mac/Windows)
+          # - trading_bot:9100          # If running inside Docker network
+    metrics_path: /metrics
+    scrape_interval: 10s
+    scrape_timeout: 5s
+
+  # Prometheus self-monitoring
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - localhost:9090

--- a/deployment/monitoring/sentry_init.py
+++ b/deployment/monitoring/sentry_init.py
@@ -1,0 +1,163 @@
+"""
+Sentry runtime exception tracking (H5 — Week 78).
+
+Initialises Sentry with:
+- before_send scrubbing: credential fields and raw price data are stripped
+- traces_sample_rate: 0.1 (10% of transactions sampled for performance)
+- environment tag from TRADING_ENV env var (default "local")
+
+Usage (in application entry point):
+    from deployment.monitoring.sentry_init import init_sentry
+    init_sentry(dsn=config.get("sentry_dsn"))
+
+Or via config/monitoring.yaml:
+    monitoring:
+      sentry_dsn: "https://...@sentry.io/..."
+      sentry_traces_sample_rate: 0.1
+      sentry_environment: "paper"
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Fields whose values must never appear in Sentry events
+_SCRUB_KEYS = frozenset({
+    # Credentials
+    "api_key", "api_secret", "secret", "token", "password", "passphrase",
+    "private_key", "secret_key", "exchange_key", "telegram_token",
+    "discord_webhook_url", "webhook_url", "telegram_chat_id",
+    # Exchange key patterns
+    "BINANCE_API_KEY", "BINANCE_SECRET", "COINBASE_API_KEY",
+    "EXCHANGE_BINANCE_TESTNET_KEY",
+})
+
+# Regex for values that look like API keys / secrets (base64-ish, long hex, etc.)
+_SECRET_VALUE_RE = re.compile(
+    r"^[A-Za-z0-9+/=_\-]{32,}$"
+)
+
+# Price data field names — strip raw OHLCV arrays to avoid quota bloat
+_PRICE_KEYS = frozenset({
+    "open", "high", "low", "close", "volume",
+    "prices", "ohlcv", "candles", "ticks", "price_data",
+    "observation", "obs",
+})
+
+_PLACEHOLDER = "[scrubbed]"
+
+
+def _scrub_dict(data: Any, depth: int = 0) -> Any:
+    """Recursively scrub sensitive fields from a Sentry event payload."""
+    if depth > 10:
+        return data
+    if isinstance(data, dict):
+        return {
+            k: _PLACEHOLDER
+            if (k.lower() in _SCRUB_KEYS or k in _SCRUB_KEYS)
+            else _PLACEHOLDER
+            if (k.lower() in _PRICE_KEYS and isinstance(v, (list, dict)) and len(str(v)) > 200)
+            else _scrub_dict(v, depth + 1)
+            for k, v in data.items()
+            for v in [data[k]]  # bind v once
+        }
+    if isinstance(data, list):
+        return [_scrub_dict(item, depth + 1) for item in data]
+    # Scrub bare string values that look like secrets
+    if isinstance(data, str) and _SECRET_VALUE_RE.match(data) and len(data) >= 32:
+        return _PLACEHOLDER
+    return data
+
+
+def _before_send(event: Dict[str, Any], hint: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Sentry before_send hook — scrub credentials and price data."""
+    # Scrub extra / request context
+    for section in ("extra", "request", "user", "contexts"):
+        if section in event:
+            event[section] = _scrub_dict(event[section])
+
+    # Scrub local variables in stack frames
+    if "exception" in event:
+        for exc_val in event["exception"].get("values", []):
+            if "stacktrace" in exc_val:
+                for frame in exc_val["stacktrace"].get("frames", []):
+                    if "vars" in frame:
+                        frame["vars"] = _scrub_dict(frame["vars"])
+
+    return event
+
+
+def init_sentry(
+    dsn: Optional[str] = None,
+    traces_sample_rate: float = 0.1,
+    environment: Optional[str] = None,
+) -> bool:
+    """Initialise Sentry SDK.
+
+    Parameters
+    ----------
+    dsn:
+        Sentry project DSN. Falls back to SENTRY_DSN env var.
+        If neither is set, Sentry remains disabled (no-op).
+    traces_sample_rate:
+        Fraction of transactions to sample for performance monitoring (0–1).
+    environment:
+        Sentry environment tag (e.g. "paper", "live", "local").
+        Falls back to TRADING_ENV env var, then "local".
+
+    Returns
+    -------
+    bool
+        True if Sentry was successfully initialised.
+    """
+    resolved_dsn = dsn or os.environ.get("SENTRY_DSN")
+    if not resolved_dsn:
+        logger.info("Sentry DSN not configured — exception tracking disabled")
+        return False
+
+    try:
+        import sentry_sdk
+    except ImportError:
+        logger.warning("sentry-sdk not installed — exception tracking disabled")
+        return False
+
+    resolved_env = environment or os.environ.get("TRADING_ENV", "local")
+
+    sentry_sdk.init(
+        dsn=resolved_dsn,
+        traces_sample_rate=max(0.0, min(1.0, traces_sample_rate)),
+        environment=resolved_env,
+        before_send=_before_send,
+        # Never send raw request bodies (may contain order data)
+        request_bodies="never",
+        # Attach local variables to stack traces (scrubbed by before_send)
+        attach_stacktrace=True,
+        # Ignore common noisy exceptions
+        ignore_errors=[KeyboardInterrupt, SystemExit],
+    )
+
+    logger.info(
+        "Sentry initialised | env=%s traces_sample_rate=%.2f",
+        resolved_env,
+        traces_sample_rate,
+    )
+    return True
+
+
+def capture_exception(exc: BaseException, context: Optional[Dict[str, Any]] = None) -> None:
+    """Capture an exception to Sentry with optional scrubbed context."""
+    try:
+        import sentry_sdk
+        with sentry_sdk.push_scope() as scope:
+            if context:
+                scrubbed = _scrub_dict(context)
+                for k, v in scrubbed.items():
+                    scope.set_extra(k, v)
+            sentry_sdk.capture_exception(exc)
+    except Exception:
+        pass  # never let Sentry crash the trading loop

--- a/deployment/monitoring/tracing.py
+++ b/deployment/monitoring/tracing.py
@@ -1,0 +1,188 @@
+"""
+OpenTelemetry tracing integration (H4 — Week 78).
+
+Replaces ad-hoc timestamp diffs with OTel spans so latency is
+automatically propagated to any OTLP-compatible backend.
+
+Span naming convention:
+    trading.order.submit        – full order round-trip (submit → exchange ack)
+    trading.order.risk_check    – UnifiedRiskManager pre-trade check
+    trading.order.compliance    – pre-trade compliance gate (limits, wash-trade)
+    trading.agent.decide        – agent.predict() call
+    trading.data.feed_tick      – single market data tick processing
+
+Usage (in OrderManager.submit_order):
+    with start_span("trading.order.submit", attributes={"symbol": symbol}) as span:
+        ...
+        span.set_attribute("order.id", order_id)
+
+Configuration:
+    Set OTEL_EXPORTER_OTLP_ENDPOINT env var to send to a collector
+    (e.g. http://localhost:4318 for Jaeger OTLP HTTP).
+    Defaults to ConsoleSpanExporter if not set (prints to stdout).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from typing import Any, Dict, Generator, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        ConsoleSpanExporter,
+        SimpleSpanProcessor,
+    )
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.semconv.resource import ResourceAttributes
+
+    HAS_OTEL = True
+except ImportError:
+    HAS_OTEL = False
+    logger.info("opentelemetry-sdk not installed; tracing disabled")
+
+_tracer: Optional[Any] = None
+_provider: Optional[Any] = None
+
+
+def init_tracing(
+    service_name: str = "trading-bot",
+    otlp_endpoint: Optional[str] = None,
+) -> None:
+    """Initialise the global OTel tracer.
+
+    Call once at application startup (e.g. in PaperTrader.__init__).
+
+    Parameters
+    ----------
+    service_name:
+        OTel resource service.name attribute.
+    otlp_endpoint:
+        OTLP HTTP endpoint (e.g. http://localhost:4318).
+        Falls back to OTEL_EXPORTER_OTLP_ENDPOINT env var, then ConsoleSpanExporter.
+    """
+    global _tracer, _provider
+
+    if not HAS_OTEL:
+        logger.warning("OTel not available — tracing disabled")
+        return
+
+    if _provider is not None:
+        return  # already initialised
+
+    resource = Resource(attributes={ResourceAttributes.SERVICE_NAME: service_name})
+    _provider = TracerProvider(resource=resource)
+
+    endpoint = otlp_endpoint or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if endpoint:
+        try:
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+            exporter = OTLPSpanExporter(endpoint=f"{endpoint.rstrip('/')}/v1/traces")
+            _provider.add_span_processor(BatchSpanProcessor(exporter))
+            logger.info("OTel tracing → OTLP endpoint: %s", endpoint)
+        except ImportError:
+            logger.warning(
+                "opentelemetry-exporter-otlp not installed; falling back to console exporter"
+            )
+            _provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+    else:
+        # Local dev: print spans to stdout so they're visible without a collector
+        _provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+        logger.info("OTel tracing → ConsoleSpanExporter (set OTEL_EXPORTER_OTLP_ENDPOINT to use OTLP)")
+
+    trace.set_tracer_provider(_provider)
+    _tracer = trace.get_tracer(service_name)
+    logger.info("OTel tracer initialised (service=%s)", service_name)
+
+
+def get_tracer() -> Any:
+    """Return the global tracer (or a no-op proxy if OTel unavailable)."""
+    if not HAS_OTEL:
+        return _NoopTracer()
+    if _tracer is None:
+        return trace.get_tracer("trading-bot")
+    return _tracer
+
+
+@contextmanager
+def start_span(
+    name: str,
+    attributes: Optional[Dict[str, Any]] = None,
+) -> Generator[Any, None, None]:
+    """Context manager that wraps a code block in an OTel span.
+
+    Safe to use even when OTel is not initialised — yields a no-op span.
+
+    Parameters
+    ----------
+    name:
+        Span name (e.g. "trading.order.submit").
+    attributes:
+        Initial span attributes dict.
+
+    Example
+    -------
+    with start_span("trading.order.submit", {"symbol": "BTCUSDT"}) as span:
+        result = exchange.create_order(...)
+        span.set_attribute("order.id", result["id"])
+    """
+    tracer = get_tracer()
+    with tracer.start_as_current_span(name) as span:
+        if attributes and HAS_OTEL:
+            for k, v in attributes.items():
+                span.set_attribute(k, v)
+        try:
+            yield span
+        except Exception as exc:
+            if HAS_OTEL:
+                span.record_exception(exc)
+                span.set_status(trace.StatusCode.ERROR, str(exc))
+            raise
+
+
+def record_order_latency(span: Any, latency_ms: float) -> None:
+    """Attach order latency to the current span as an attribute."""
+    if HAS_OTEL and span is not None:
+        span.set_attribute("order.latency_ms", latency_ms)
+
+
+def shutdown_tracing() -> None:
+    """Flush and shut down the tracer provider. Call on application exit."""
+    global _provider, _tracer
+    if _provider is not None and HAS_OTEL:
+        _provider.shutdown()
+        _provider = None
+        _tracer = None
+
+
+# ------------------------------------------------------------------
+# No-op fallback when OTel is not installed
+# ------------------------------------------------------------------
+
+class _NoopSpan:
+    def set_attribute(self, key: str, value: Any) -> None:
+        pass
+
+    def record_exception(self, exc: Exception) -> None:
+        pass
+
+    def set_status(self, *args: Any) -> None:
+        pass
+
+    def __enter__(self) -> "_NoopSpan":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+class _NoopTracer:
+    @contextmanager
+    def start_as_current_span(self, name: str) -> Generator[_NoopSpan, None, None]:
+        yield _NoopSpan()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,63 @@ services:
       - default
 
   # ──────────────────────────────────────────────────────────
+  # ──────────────────────────────────────────────────────────
+  # Prometheus (Week 78: H1) — scrapes bot metrics from :9100
+  # ──────────────────────────────────────────────────────────
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    container_name: trading_prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./deployment/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=30d"
+      - "--web.enable-lifecycle"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    profiles:
+      - observability
+      - default
+
+  # ──────────────────────────────────────────────────────────
+  # Grafana (Week 78: H2) — dashboard UI at :3000
+  # ──────────────────────────────────────────────────────────
+  grafana:
+    image: grafana/grafana:10.4.0
+    container_name: trading_grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=trading_admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/trading_bot.json
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./deployment/monitoring/grafana_dashboard.json:/var/lib/grafana/dashboards/trading_bot.json:ro
+      - ./deployment/monitoring/grafana_provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    profiles:
+      - observability
+      - default
+
   # Data Fetcher (cron-style daily update)
   # ──────────────────────────────────────────────────────────
   data_fetcher:
@@ -160,6 +217,10 @@ services:
 # ──────────────────────────────────────────────────────────
 volumes:
   mlruns:
+    driver: local
+  prometheus_data:
+    driver: local
+  grafana_data:
     driver: local
 
 networks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,6 +64,12 @@ requests>=2.31.0             # CoinGecko API calls for on-chain features
 # Week 27: Data fetcher (cross-asset + traditional markets)
 yfinance>=0.2.40             # SPY, DXY, VIX, Gold, US10Y data
 
+# Observability (Week 78)
+prometheus_client>=0.20.0       # Prometheus metrics export
+sentry-sdk>=2.0.0               # Runtime exception tracking
+opentelemetry-api>=1.20.0       # OTel tracing API
+opentelemetry-sdk>=1.20.0       # OTel tracing SDK
+
 # Utilities
 python-dotenv>=1.0.1
 pydantic>=2.10.4

--- a/tests/test_week78_observability.py
+++ b/tests/test_week78_observability.py
@@ -1,0 +1,487 @@
+"""
+Week 78 (H1-H5) Observability Stack tests.
+
+H1: Prometheus integration — all snapshot fields exported
+H2: Grafana dashboard JSON — well-formed, required panels present
+H3: Alerter extensions — Discord channel, notify_error/kill_switch/audit_chain_break
+H4: OpenTelemetry tracing — span context manager, no-op fallback
+H5: Sentry scrubbing — credential and price data stripped from events
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deployment.monitoring.alerter import TradingAlerter, AlertRecord
+from deployment.monitoring.metrics_exporter import MetricsExporter, MetricSnapshot
+from deployment.monitoring.sentry_init import _scrub_dict, _before_send
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# H1: Prometheus integration
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPrometheusIntegration:
+    """MetricsExporter Prometheus backend — all fields mapped."""
+
+    def test_prometheus_disabled_by_default(self):
+        exporter = MetricsExporter()
+        assert exporter._use_prometheus is False
+
+    def test_prometheus_enabled_with_flag(self):
+        """When use_prometheus=True and prometheus_client available, server starts."""
+        import prometheus_client  # noqa: F401 — assert package present
+
+        started_ports = []
+
+        def fake_start(port):
+            started_ports.append(port)
+
+        with patch("deployment.monitoring.metrics_exporter.start_http_server", fake_start):
+            exporter = MetricsExporter({"use_prometheus": True, "prometheus_port": 19100})
+
+        assert exporter._use_prometheus is True
+        assert 19100 in started_ports
+
+    def test_all_prom_gauges_registered(self):
+        """All MetricSnapshot fields have a corresponding Prometheus entry in _prom."""
+        # Patch metric classes so we don't hit the global CollectorRegistry
+        with patch("deployment.monitoring.metrics_exporter.start_http_server"), \
+             patch("deployment.monitoring.metrics_exporter.Gauge", MagicMock()), \
+             patch("deployment.monitoring.metrics_exporter.Counter", MagicMock()), \
+             patch("deployment.monitoring.metrics_exporter.Histogram", MagicMock()):
+            exporter = MetricsExporter({"use_prometheus": True, "prometheus_port": 19101})
+
+        expected_keys = {
+            "portfolio_value", "cash", "position", "unrealised_pnl", "realised_pnl",
+            "daily_pnl", "drawdown_pct", "current_var", "is_halted", "kill_switch_active",
+            "win_rate", "sharpe_ratio", "rolling_sharpe", "rolling_sortino",
+            "pnl_market_move", "pnl_slippage_cost", "pnl_fees", "pnl_net",
+            "drift_detected", "current_regime",
+            "latency_p50_ms", "latency_p95_ms", "latency_p99_ms",
+            "order_latency_histogram",
+            "num_trades", "alerts_fired", "feature_drift_alarms",
+        }
+        assert expected_keys.issubset(set(exporter._prom.keys()))
+
+    def test_update_pushes_all_gauges(self):
+        """After update(), all gauge values reflect the snapshot."""
+        set_values: Dict[str, Any] = {}
+
+        class FakeGauge:
+            def __init__(self, name, *a, **k):
+                self.name = name
+
+            def set(self, v):
+                set_values[self.name] = v
+
+        class FakeCounter:
+            def __init__(self, *a, **k):
+                pass
+
+            def inc(self, v=1):
+                pass
+
+        class FakeHistogram:
+            def __init__(self, *a, **k):
+                pass
+
+            def observe(self, v):
+                pass
+
+        with patch("deployment.monitoring.metrics_exporter.start_http_server"), \
+             patch("deployment.monitoring.metrics_exporter.Gauge", FakeGauge), \
+             patch("deployment.monitoring.metrics_exporter.Counter", FakeCounter), \
+             patch("deployment.monitoring.metrics_exporter.Histogram", FakeHistogram):
+            exporter = MetricsExporter({"use_prometheus": True, "prometheus_port": 19102})
+            exporter.update(
+                portfolio_value=12345.0,
+                drawdown_pct=0.07,
+                is_halted=True,
+                kill_switch_active=True,
+            )
+
+        assert set_values.get("trading_portfolio_value_usd") == pytest.approx(12345.0)
+        assert set_values.get("trading_drawdown_pct") == pytest.approx(0.07)
+        assert set_values.get("trading_is_halted") == 1.0
+        assert set_values.get("trading_kill_switch_active") == 1.0
+
+    def test_observe_order_latency(self):
+        """observe_order_latency() calls histogram.observe()."""
+        observed = []
+
+        class FakeHistogram:
+            def __init__(self, *a, **k):
+                pass
+
+            def observe(self, v):
+                observed.append(v)
+
+        with patch("deployment.monitoring.metrics_exporter.start_http_server"), \
+             patch("deployment.monitoring.metrics_exporter.Gauge", MagicMock), \
+             patch("deployment.monitoring.metrics_exporter.Counter", MagicMock), \
+             patch("deployment.monitoring.metrics_exporter.Histogram", FakeHistogram):
+            exporter = MetricsExporter({"use_prometheus": True, "prometheus_port": 19103})
+            exporter.observe_order_latency(42.5)
+
+        assert observed == [42.5]
+
+    def test_counter_delta_only(self):
+        """Counter.inc() is called with delta (not absolute value)."""
+        incs = []
+
+        class FakeGauge:
+            def __init__(self, *a, **k):
+                pass
+            def set(self, v):
+                pass
+
+        class FakeCounter:
+            def __init__(self, *a, **k):
+                pass
+            def inc(self, v=1):
+                incs.append(v)
+
+        class FakeHistogram:
+            def __init__(self, *a, **k):
+                pass
+            def observe(self, v):
+                pass
+
+        with patch("deployment.monitoring.metrics_exporter.start_http_server"), \
+             patch("deployment.monitoring.metrics_exporter.Gauge", FakeGauge), \
+             patch("deployment.monitoring.metrics_exporter.Counter", FakeCounter), \
+             patch("deployment.monitoring.metrics_exporter.Histogram", FakeHistogram):
+            exporter = MetricsExporter({"use_prometheus": True, "prometheus_port": 19104})
+            exporter.update(num_trades=5, alerts_fired=2)
+            exporter.update(num_trades=7, alerts_fired=3)
+
+        # First update: delta 5 trades, 2 alerts
+        # Second update: delta 2 trades, 1 alert
+        assert 5 in incs
+        assert 2 in incs
+        assert 1 in incs
+
+    def test_kill_switch_field_in_snapshot(self):
+        """MetricSnapshot has kill_switch_active field."""
+        exporter = MetricsExporter()
+        snap = exporter.update(kill_switch_active=True)
+        assert snap.kill_switch_active is True
+        assert exporter.to_json()["kill_switch_active"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# H2: Grafana dashboard JSON
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGrafanaDashboard:
+    """grafana_dashboard.json — structural validity checks."""
+
+    @pytest.fixture(scope="class")
+    def dashboard(self) -> Dict[str, Any]:
+        path = Path(__file__).parent.parent / "deployment/monitoring/grafana_dashboard.json"
+        return json.loads(path.read_text())
+
+    def test_file_is_valid_json(self, dashboard):
+        assert isinstance(dashboard, dict)
+
+    def test_required_top_level_keys(self, dashboard):
+        for key in ("title", "panels", "uid", "schemaVersion", "refresh"):
+            assert key in dashboard, f"Missing key: {key}"
+
+    def test_has_prometheus_input(self, dashboard):
+        inputs = dashboard.get("__inputs", [])
+        assert any(i.get("pluginId") == "prometheus" for i in inputs)
+
+    def test_panels_cover_required_topics(self, dashboard):
+        all_text = json.dumps(dashboard).lower()
+        required_topics = [
+            "pnl",          # P&L attribution
+            "latency",      # order latency
+            "drawdown",     # drawdown panel
+            "drift",        # drift alarms
+            "kill_switch",  # kill switch status
+        ]
+        for topic in required_topics:
+            assert topic in all_text, f"Dashboard missing panel for: {topic}"
+
+    def test_uid_is_set(self, dashboard):
+        assert dashboard["uid"] not in (None, ""), "Dashboard UID must be set"
+
+    def test_auto_refresh(self, dashboard):
+        assert dashboard.get("refresh") not in (None, ""), "Dashboard should auto-refresh"
+
+    def test_panel_count(self, dashboard):
+        panels = [p for p in dashboard["panels"] if p.get("type") != "row"]
+        assert len(panels) >= 8, f"Expected at least 8 data panels, got {len(panels)}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# H3: Alerter extensions
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAlerterExtensions:
+    """New methods and Discord channel added in H3."""
+
+    def _make_alerter(self, extra_config=None):
+        cfg = {"alert_channels": ["console"]}
+        if extra_config:
+            cfg.update(extra_config)
+        return TradingAlerter(cfg)
+
+    # notify_error ────────────────────────────────────────────
+
+    def test_notify_error_records_alert(self):
+        alerter = self._make_alerter()
+        alerter.notify_error("connection refused", context="order_submit")
+        assert len(alerter.alert_history) == 1
+        rec = alerter.alert_history[0]
+        assert rec.event == "runtime_error"
+        assert rec.level == "ERROR"
+        assert "connection refused" in rec.message
+
+    def test_notify_error_without_context(self):
+        alerter = self._make_alerter()
+        alerter.notify_error("timeout")
+        assert alerter.alert_history[0].message == "Runtime error: timeout"
+
+    # notify_kill_switch ──────────────────────────────────────
+
+    def test_notify_kill_switch_records_critical(self):
+        alerter = self._make_alerter()
+        alerter.notify_kill_switch(reason="drawdown_exceeded")
+        rec = alerter.alert_history[0]
+        assert rec.event == "kill_switch_activated"
+        assert rec.level == "CRITICAL"
+        assert "drawdown_exceeded" in rec.message
+
+    def test_notify_kill_switch_default_reason(self):
+        alerter = self._make_alerter()
+        alerter.notify_kill_switch()
+        assert "manual" in alerter.alert_history[0].message
+
+    # notify_audit_chain_break ────────────────────────────────
+
+    def test_notify_audit_chain_break_records(self):
+        alerter = self._make_alerter()
+        alerter.notify_audit_chain_break(details="hash mismatch at step 42")
+        rec = alerter.alert_history[0]
+        assert rec.event == "audit_chain_break"
+        assert rec.level == "CRITICAL"
+        assert "hash mismatch" in rec.message
+
+    # Discord channel ─────────────────────────────────────────
+
+    def test_discord_channel_sends_embed(self):
+        """Discord channel calls the webhook URL with an embed payload."""
+        sent_payloads = []
+
+        class FakeResponse:
+            status = 204
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def fake_urlopen(req, timeout=10):
+            sent_payloads.append(json.loads(req.data.decode()))
+            return FakeResponse()
+
+        alerter = TradingAlerter({
+            "alert_channels": ["discord"],
+            "discord_webhook_url": "https://discord.com/api/webhooks/fake/url",
+        })
+        with patch("deployment.monitoring.alerter.urllib.request.urlopen", fake_urlopen):
+            alerter.send_alert("test discord message", level="WARNING")
+
+        assert len(sent_payloads) == 1
+        payload = sent_payloads[0]
+        assert "embeds" in payload
+        embed = payload["embeds"][0]
+        assert "test discord message" in embed["description"]
+        assert embed["title"].startswith("[WARNING]")
+
+    def test_discord_no_url_logs_warning(self, caplog):
+        """Discord channel with no URL logs a warning, no exception."""
+        import logging
+        alerter = TradingAlerter({"alert_channels": ["discord"]})
+        with caplog.at_level(logging.WARNING):
+            alerter.send_alert("test")
+        assert "discord_webhook_url" in caplog.text.lower() or "discord" in caplog.text.lower()
+
+    def test_discord_env_var_override(self, monkeypatch):
+        """DISCORD_WEBHOOK_URL env var is picked up."""
+        monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.com/api/webhooks/env/url")
+        alerter = TradingAlerter({"alert_channels": ["discord"]})
+        assert alerter._discord_url == "https://discord.com/api/webhooks/env/url"
+
+    def test_all_channels_record_history(self):
+        """alert_history is populated regardless of channel."""
+        alerter = TradingAlerter({"alert_channels": ["console"]})
+        alerter.notify_error("e1")
+        alerter.notify_kill_switch()
+        alerter.notify_audit_chain_break()
+        assert len(alerter.alert_history) == 3
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# H4: OpenTelemetry tracing
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestOTelTracing:
+    """start_span() context manager — functional and no-op paths."""
+
+    def test_start_span_no_exception(self):
+        """start_span runs without error when OTel is available."""
+        from deployment.monitoring.tracing import start_span
+        with start_span("trading.test.span", {"key": "val"}) as span:
+            assert span is not None
+
+    def test_start_span_records_exception(self):
+        """start_span re-raises exceptions and records them on the span."""
+        from deployment.monitoring.tracing import start_span
+        with pytest.raises(ValueError, match="deliberate"):
+            with start_span("trading.test.error"):
+                raise ValueError("deliberate")
+
+    def test_noop_tracer_safe(self):
+        """_NoopTracer is safe to use directly."""
+        from deployment.monitoring.tracing import _NoopTracer
+        tracer = _NoopTracer()
+        with tracer.start_as_current_span("test") as span:
+            span.set_attribute("k", "v")  # no error
+
+    def test_get_tracer_returns_tracer(self):
+        """get_tracer() returns a usable tracer."""
+        from deployment.monitoring.tracing import get_tracer
+        tracer = get_tracer()
+        assert tracer is not None
+
+    def test_init_tracing_idempotent(self):
+        """Calling init_tracing() twice does not raise."""
+        from deployment.monitoring import tracing
+        # Reset state
+        tracing._provider = None
+        tracing._tracer = None
+        tracing.init_tracing(service_name="test-bot-idempotent")
+        tracing.init_tracing(service_name="test-bot-idempotent")  # second call — no error
+
+    def test_shutdown_tracing(self):
+        """shutdown_tracing() does not raise."""
+        from deployment.monitoring.tracing import shutdown_tracing
+        shutdown_tracing()  # idempotent
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# H5: Sentry scrubbing
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSentryScrubbing:
+    """_scrub_dict and _before_send strip credentials and price arrays."""
+
+    def test_api_key_scrubbed(self):
+        data = {"api_key": "SUPER_SECRET_1234567890abcdef"}
+        result = _scrub_dict(data)
+        assert result["api_key"] == "[scrubbed]"
+
+    def test_nested_secret_scrubbed(self):
+        data = {"exchange": {"api_secret": "abc123def456abc123def456abc123de"}}
+        result = _scrub_dict(data)
+        assert result["exchange"]["api_secret"] == "[scrubbed]"
+
+    def test_large_price_array_scrubbed(self):
+        """A 'prices' key with a large array is scrubbed."""
+        data = {"prices": list(range(500))}
+        result = _scrub_dict(data)
+        assert result["prices"] == "[scrubbed]"
+
+    def test_small_price_array_kept(self):
+        """A small list under 200 chars is not scrubbed."""
+        data = {"prices": [1.0, 2.0, 3.0]}
+        result = _scrub_dict(data)
+        # Small list — not scrubbed
+        assert result["prices"] == [1.0, 2.0, 3.0]
+
+    def test_non_sensitive_keys_kept(self):
+        data = {"symbol": "BTCUSDT", "portfolio_value": 10000.0}
+        result = _scrub_dict(data)
+        assert result["symbol"] == "BTCUSDT"
+        assert result["portfolio_value"] == 10000.0
+
+    def test_long_base64_string_scrubbed(self):
+        """Bare long base64-ish strings are scrubbed at the value level."""
+        long_secret = "A" * 64
+        data = {"some_field": long_secret}
+        result = _scrub_dict(data)
+        assert result["some_field"] == "[scrubbed]"
+
+    def test_short_string_kept(self):
+        short = "hello"
+        data = {"msg": short}
+        result = _scrub_dict(data)
+        assert result["msg"] == "hello"
+
+    def test_before_send_scrubs_extra(self):
+        event = {
+            "extra": {"api_key": "SECRETKEY12345678901234567890ab"},
+            "exception": {"values": []},
+        }
+        cleaned = _before_send(event, {})
+        assert cleaned["extra"]["api_key"] == "[scrubbed]"
+
+    def test_before_send_scrubs_frame_vars(self):
+        event = {
+            "exception": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {"vars": {"api_secret": "mysecret1234567890abc123def456"}}
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+        cleaned = _before_send(event, {})
+        frame_vars = cleaned["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]
+        assert frame_vars["api_secret"] == "[scrubbed]"
+
+    def test_init_sentry_no_dsn(self):
+        """init_sentry() returns False and does not raise when no DSN set."""
+        from deployment.monitoring.sentry_init import init_sentry
+        result = init_sentry(dsn=None)
+        assert result is False
+
+    def test_init_sentry_with_dsn(self):
+        """init_sentry() calls sentry_sdk.init with correct args."""
+        from deployment.monitoring.sentry_init import init_sentry
+        with patch("sentry_sdk.init") as mock_init:
+            result = init_sentry(
+                dsn="https://test@sentry.io/123",
+                traces_sample_rate=0.2,
+                environment="paper",
+            )
+        assert result is True
+        mock_init.assert_called_once()
+        kwargs = mock_init.call_args[1]
+        assert kwargs["environment"] == "paper"
+        assert kwargs["traces_sample_rate"] == pytest.approx(0.2)
+        assert callable(kwargs["before_send"])
+
+    def test_capture_exception_silent_on_error(self):
+        """capture_exception() never raises even if Sentry internals fail."""
+        from deployment.monitoring.sentry_init import capture_exception
+        with patch("sentry_sdk.push_scope", side_effect=RuntimeError("sentry broke")):
+            # Must not propagate
+            capture_exception(ValueError("test"), context={"api_key": "secret"})


### PR DESCRIPTION
## Summary

- **H1 Prometheus**: `MetricsExporter` 30개 필드 전부 Gauge/Counter/Histogram 매핑, `:9100/metrics` HTTP 서버, delta-only Counter
- **H2 Grafana**: `deployment/monitoring/grafana_dashboard.json` (import-ready) — PnL attribution, latency p50/95/99, drawdown, drift alarms, kill switch 패널 12개
- **H3 Alerter**: Discord webhook 채널 + `notify_error()` / `notify_kill_switch()` / `notify_audit_chain_break()` 추가
- **H4 OTel**: `deployment/monitoring/tracing.py` — `start_span()` context manager, OTLP/Console 자동 선택, no-op 폴백
- **H5 Sentry**: `deployment/monitoring/sentry_init.py` — `before_send` scrubbing (API key, price array), `capture_exception()` silent
- **Infra**: docker-compose Prometheus(`:9090`) + Grafana(`:3000`) 서비스 + auto-provisioning

## 완료 조건 확인

- [x] Prometheus/Grafana 로컬 stack에서 PaperTrader 실시간 메트릭 관찰 가능 (`docker-compose up prometheus grafana`)
- [x] 알람 2개 이상 채널 연동 (Discord + Telegram/Webhook — 설정 시 즉시 활성)

## Test plan

- [x] `tests/test_week78_observability.py` — 41 tests / 41 passed
- [x] `tests/test_metrics_exporter.py` — 8 tests / 8 passed (regression: 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)