### PR TITLE
[A0.5] Live-readiness signal gate

### DIFF
--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -47,6 +47,19 @@ sandbox:
   api_key_ref: "EXCHANGE_BINANCE_TESTNET_KEY"
   api_secret_ref: "EXCHANGE_BINANCE_TESTNET_SECRET"
 
+# ── Live Signal Gate (A0.5) ───────────────────────────────────
+# Blocks exchange_mode: live until strategy evidence passes all thresholds.
+# Parsed by deployment/governance/live_signal_gate.py.
+live_signal_gate:
+  evidence_pack: "docs/phase8/strategy_evidence_v1.md"
+  max_evidence_age_days: 30
+  thresholds:
+    min_sharpe_net: 0.5
+    min_dsr: 0.0
+    min_bootstrap_ci_lower: 0.0
+    max_permutation_p: 0.05
+    max_regime_dd: 0.30
+
 # ── LLM Review Panel ──────────────────────────────────────────
 llm_review:
   enabled: false

--- a/deployment/governance/__init__.py
+++ b/deployment/governance/__init__.py
@@ -1,0 +1,1 @@
+"""Deployment governance: live-readiness gates and operator controls."""

--- a/deployment/governance/live_signal_gate.py
+++ b/deployment/governance/live_signal_gate.py
@@ -1,0 +1,325 @@
+"""[A0.5] Live-readiness signal gate.
+
+Parses the YAML frontmatter of docs/phase8/strategy_evidence_v1.md and
+validates all strategy thresholds before allowing exchange_mode: live.
+
+Exit codes (when used as __main__):
+    0 — all checks passed
+    2 — gate failed (one or more thresholds not met)
+    1 — error (evidence pack missing / malformed)
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deployment.monitoring.alerter import TradingAlerter
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Default thresholds (mirror config/deployment.yaml live_signal_gate section)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_THRESHOLDS: Dict[str, Any] = {
+    "min_sharpe_net": 0.5,
+    "min_dsr": 0.0,
+    "min_bootstrap_ci_lower": 0.0,
+    "max_permutation_p": 0.05,
+    "max_regime_dd": 0.30,
+}
+
+_DEFAULT_MAX_EVIDENCE_AGE_DAYS: float = 30.0
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SignalGateResult:
+    passed: bool
+    failures: List[str] = field(default_factory=list)
+    metrics: Dict[str, Any] = field(default_factory=dict)
+    evidence_pack_path: Optional[Path] = None
+    evidence_pack_age_days: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Gate
+# ---------------------------------------------------------------------------
+
+class LiveSignalGate:
+    """Validate strategy evidence pack before allowing live trading.
+
+    Parameters
+    ----------
+    evidence_pack:
+        Path to ``strategy_evidence_v1.md`` (YAML frontmatter required).
+    thresholds:
+        Override dict; missing keys fall back to ``_DEFAULT_THRESHOLDS``.
+    max_evidence_age_days:
+        Evidence pack must have been generated within this many days.
+    alerter:
+        Optional :class:`TradingAlerter` — called on gate failure.
+    _now:
+        Override "now" datetime (UTC) for testing.
+    """
+
+    def __init__(
+        self,
+        evidence_pack: Path,
+        thresholds: Optional[Dict[str, Any]] = None,
+        max_evidence_age_days: float = _DEFAULT_MAX_EVIDENCE_AGE_DAYS,
+        alerter: Optional["TradingAlerter"] = None,
+        _now: Optional[datetime] = None,
+    ) -> None:
+        self.evidence_pack = Path(evidence_pack)
+        self.thresholds = dict(_DEFAULT_THRESHOLDS)
+        if thresholds:
+            self.thresholds.update(thresholds)
+        self.max_evidence_age_days = max_evidence_age_days
+        self.alerter = alerter
+        self._now = _now
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def check(self) -> SignalGateResult:
+        """Run all gate checks and return a :class:`SignalGateResult`."""
+        failures: List[str] = []
+
+        # 1. Evidence pack exists
+        if not self.evidence_pack.exists():
+            return SignalGateResult(
+                passed=False,
+                failures=[f"Evidence pack not found: {self.evidence_pack}"],
+                evidence_pack_path=self.evidence_pack,
+            )
+
+        # 2. Parse frontmatter
+        try:
+            frontmatter = _parse_frontmatter(self.evidence_pack)
+        except ValueError as exc:
+            return SignalGateResult(
+                passed=False,
+                failures=[f"Evidence pack parse error: {exc}"],
+                evidence_pack_path=self.evidence_pack,
+            )
+
+        metrics = frontmatter.get("metrics", {})
+
+        # 3. Age check
+        age_days = self._compute_age_days(frontmatter)
+        if age_days > self.max_evidence_age_days:
+            failures.append(
+                f"Evidence pack is {age_days:.1f} days old "
+                f"(max {self.max_evidence_age_days:.0f} days)"
+            )
+
+        # 4. Net Sharpe
+        net_sharpe = _get_float(metrics, "net_sharpe")
+        if net_sharpe is None:
+            failures.append("metrics.net_sharpe missing")
+        elif net_sharpe <= self.thresholds["min_sharpe_net"]:
+            failures.append(
+                f"net_sharpe {net_sharpe:.4f} ≤ threshold {self.thresholds['min_sharpe_net']}"
+            )
+
+        # 5. DSR
+        dsr = _get_float(metrics, "dsr")
+        if dsr is None:
+            failures.append("metrics.dsr missing")
+        elif dsr <= self.thresholds["min_dsr"]:
+            failures.append(
+                f"dsr {dsr:.4f} ≤ threshold {self.thresholds['min_dsr']}"
+            )
+
+        # 6. Bootstrap CI lower
+        ci_lower = _get_float(metrics, "bootstrap_ci_lower")
+        if ci_lower is None:
+            failures.append("metrics.bootstrap_ci_lower missing")
+        elif ci_lower <= self.thresholds["min_bootstrap_ci_lower"]:
+            failures.append(
+                f"bootstrap_ci_lower {ci_lower:.4f} ≤ threshold "
+                f"{self.thresholds['min_bootstrap_ci_lower']}"
+            )
+
+        # 7. Permutation p-value
+        perm_p = _get_float(metrics, "permutation_p")
+        if perm_p is None:
+            failures.append("metrics.permutation_p missing")
+        elif perm_p >= self.thresholds["max_permutation_p"]:
+            failures.append(
+                f"permutation_p {perm_p:.4f} ≥ threshold {self.thresholds['max_permutation_p']}"
+            )
+
+        # 8. Max regime DD (crisis)
+        max_regime_dd_cfg = self.thresholds["max_regime_dd"]
+        regime_dd = metrics.get("max_regime_dd", {})
+        if not isinstance(regime_dd, dict):
+            failures.append("metrics.max_regime_dd must be a mapping of regime→float")
+        else:
+            for regime, dd_val in regime_dd.items():
+                try:
+                    dd_float = float(dd_val)
+                except (TypeError, ValueError):
+                    failures.append(f"max_regime_dd.{regime} is not numeric")
+                    continue
+                if dd_float >= max_regime_dd_cfg:
+                    failures.append(
+                        f"max_regime_dd.{regime} {dd_float:.4f} ≥ threshold {max_regime_dd_cfg}"
+                    )
+
+        passed = len(failures) == 0
+        result = SignalGateResult(
+            passed=passed,
+            failures=failures,
+            metrics=metrics,
+            evidence_pack_path=self.evidence_pack,
+            evidence_pack_age_days=age_days,
+        )
+
+        if not passed and self.alerter is not None:
+            self.alerter.send_alert(
+                f"Live signal gate FAILED: {len(failures)} check(s) failed",
+                level="CRITICAL",
+            )
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _compute_age_days(self, frontmatter: Dict[str, Any]) -> float:
+        generated_at_raw = frontmatter.get("generated_at")
+        if not generated_at_raw:
+            return float("inf")
+        try:
+            generated_at = datetime.fromisoformat(str(generated_at_raw).rstrip("Z"))
+            if generated_at.tzinfo is None:
+                generated_at = generated_at.replace(tzinfo=timezone.utc)
+            now = self._now if self._now is not None else datetime.now(timezone.utc)
+            if now.tzinfo is None:
+                now = now.replace(tzinfo=timezone.utc)
+            delta = now - generated_at
+            return delta.total_seconds() / 86400.0
+        except Exception:
+            return float("inf")
+
+
+# ---------------------------------------------------------------------------
+# YAML frontmatter parser (no external deps)
+# ---------------------------------------------------------------------------
+
+def _parse_frontmatter(path: Path) -> Dict[str, Any]:
+    """Extract and parse YAML frontmatter between ``---`` delimiters."""
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    if not lines or lines[0].strip() != "---":
+        raise ValueError("No YAML frontmatter found (expected '---' on line 1)")
+
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        raise ValueError("Frontmatter closing '---' not found")
+
+    yaml_text = "\n".join(lines[1:end_idx])
+    try:
+        import yaml  # type: ignore
+        data = yaml.safe_load(yaml_text)
+    except Exception as exc:
+        raise ValueError(f"YAML parse error: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError("Frontmatter must be a YAML mapping")
+
+    return data
+
+
+def _get_float(d: Dict[str, Any], key: str) -> Optional[float]:
+    val = d.get(key)
+    if val is None:
+        return None
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point (used by check_signal_gate.py and go_live_checklist Z1)
+# ---------------------------------------------------------------------------
+
+def _cli_main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="[A0.5] Check live-readiness signal gate"
+    )
+    parser.add_argument(
+        "--evidence-pack",
+        default="docs/phase8/strategy_evidence_v1.md",
+        help="Path to strategy_evidence_v1.md",
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to deployment.yaml (reads live_signal_gate section)",
+    )
+    args = parser.parse_args(argv)
+
+    # Load config if provided
+    thresholds: Dict[str, Any] = {}
+    max_age_days = _DEFAULT_MAX_EVIDENCE_AGE_DAYS
+    evidence_pack_path = Path(args.evidence_pack)
+
+    if args.config:
+        try:
+            import yaml  # type: ignore
+            with open(args.config) as f:
+                cfg = yaml.safe_load(f) or {}
+            gate_cfg = cfg.get("live_signal_gate", {})
+            if "evidence_pack" in gate_cfg:
+                evidence_pack_path = Path(gate_cfg["evidence_pack"])
+            max_age_days = float(gate_cfg.get("max_evidence_age_days", max_age_days))
+            thresholds = gate_cfg.get("thresholds", {})
+        except Exception as exc:
+            print(f"ERROR: Failed to load config {args.config}: {exc}", file=sys.stderr)
+            return 1
+
+    gate = LiveSignalGate(
+        evidence_pack=evidence_pack_path,
+        thresholds=thresholds,
+        max_evidence_age_days=max_age_days,
+    )
+    result = gate.check()
+
+    if result.passed:
+        print("✅ Signal gate PASSED — live mode authorized")
+        print(f"   Evidence pack: {result.evidence_pack_path}")
+        print(f"   Age: {result.evidence_pack_age_days:.1f} days")
+        for k, v in result.metrics.items():
+            print(f"   {k}: {v}")
+        return 0
+    else:
+        print("❌ Signal gate FAILED — live mode NOT authorized")
+        for failure in result.failures:
+            print(f"   • {failure}")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(_cli_main())

--- a/docs/runbook/go_live_checklist.md
+++ b/docs/runbook/go_live_checklist.md
@@ -108,6 +108,26 @@ operator and documented with a timestamp.
 
 ---
 
+## Track Z — Strategy Signal Gate (A0.5)
+
+**All Z-items must be ✅ before any operational item matters. This track is code-enforced:
+`run_paper_trader.py --exchange-mode live` exits 2 if Z1–Z3 are not satisfied.**
+
+| # | Check | How | Status | Notes |
+|---|-------|-----|--------|-------|
+| Z1 | Signal gate CLI exits 0 | `python scripts/check_signal_gate.py --config config/deployment.yaml` | ☐ | Auto-enforced at live startup |
+| Z2 | Evidence pack age < 30 days | Checked by Z1 | ☐ | Regenerate if stale: `scripts/generate_evidence_pack.py` |
+| Z3 | All thresholds pass: net Sharpe > 0.5, DSR > 0, CI lower > 0, permutation p < 0.05, regime DD < 30% | Checked by Z1 | ☐ | See `docs/phase8/strategy_evidence_v1.md` |
+| Z4 | Reward audit doc exists | `ls docs/phase8/reward_audit.md` | ☐ | Required: confirms net-of-cost training |
+
+> **Z1 command (copy-paste)**:
+> ```bash
+> python scripts/check_signal_gate.py --config config/deployment.yaml
+> # Exit 0 → GO. Exit 2 → FAIL (see output). Exit 1 → config/import error.
+> ```
+
+---
+
 ## Kill Switch Keyboard Shortcut
 
 Document your kill shortcut here before going live:

--- a/scripts/check_signal_gate.py
+++ b/scripts/check_signal_gate.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""[A0.5] Operator wrapper — live-readiness signal gate check.
+
+Standalone script: runs LiveSignalGate and exits with:
+    0 — all checks passed (live mode authorized)
+    2 — gate failed (thresholds not met / evidence stale)
+    1 — error (missing file, bad config, import failure)
+
+Usage:
+    python scripts/check_signal_gate.py
+    python scripts/check_signal_gate.py --config config/deployment.yaml
+    python scripts/check_signal_gate.py --evidence-pack /path/to/evidence.md
+    python scripts/check_signal_gate.py --verbose
+
+This script is referenced by go_live_checklist.md Track Z (Z1).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from deployment.governance.live_signal_gate import _cli_main
+
+if __name__ == "__main__":
+    sys.exit(_cli_main())

--- a/scripts/run_paper_trader.py
+++ b/scripts/run_paper_trader.py
@@ -100,6 +100,36 @@ def main() -> None:
     config.setdefault("execution", {})["exchange_mode"] = args.exchange_mode
     config.setdefault("paper_trading", {})["exchange_mode"] = args.exchange_mode
 
+    # ── [A0.5] Live signal gate — block live mode until evidence passes ──────
+    if args.exchange_mode == "live":
+        try:
+            from deployment.governance.live_signal_gate import LiveSignalGate
+            gate_cfg = config.get("live_signal_gate", {})
+            evidence_pack = Path(
+                gate_cfg.get("evidence_pack", "docs/phase8/strategy_evidence_v1.md")
+            )
+            max_age = float(gate_cfg.get("max_evidence_age_days", 30))
+            thresholds = gate_cfg.get("thresholds", {})
+            gate = LiveSignalGate(
+                evidence_pack=evidence_pack,
+                thresholds=thresholds,
+                max_evidence_age_days=max_age,
+            )
+            result = gate.check()
+            if not result.passed:
+                logger.error(
+                    "❌ Live signal gate FAILED — live mode blocked:\n%s",
+                    "\n".join(f"  • {f}" for f in result.failures),
+                )
+                sys.exit(2)
+            logger.info(
+                "✅ Live signal gate PASSED (evidence age %.1f days)",
+                result.evidence_pack_age_days,
+            )
+        except ImportError as exc:
+            logger.error("Failed to import live_signal_gate: %s", exc)
+            sys.exit(1)
+
     duration_seconds: Optional[float] = (
         args.duration_hours * 3600.0 if args.duration_hours is not None else None
     )

--- a/tests/deployment/governance/test_live_signal_gate.py
+++ b/tests/deployment/governance/test_live_signal_gate.py
@@ -1,0 +1,269 @@
+"""[A0.5] Tests for deployment.governance.live_signal_gate.
+
+8 cases required by phase8-restructured spec:
+  1. All thresholds passed → gate passes
+  2. net_sharpe below threshold → gate fails
+  3. DSR below threshold → gate fails
+  4. bootstrap_ci_lower below threshold → gate fails
+  5. permutation_p above threshold → gate fails
+  6. max_regime_dd crisis above threshold → gate fails
+  7. Evidence pack age expired → gate fails
+  8. Evidence pack file missing → gate fails
+
+Plus supplementary cases:
+  9.  Multiple simultaneous failures → all listed in result.failures
+  10. Missing metrics key → failure with helpful message
+  11. Alerter called on failure
+  12. Malformed frontmatter → error result
+"""
+from __future__ import annotations
+
+import textwrap
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from deployment.governance.live_signal_gate import LiveSignalGate, SignalGateResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_pack(
+    tmp_path: Path,
+    *,
+    net_sharpe: float = 0.65,
+    gross_sharpe: float = 0.80,
+    dsr: float = 0.18,
+    bootstrap_ci_lower: float = 0.12,
+    bootstrap_ci_upper: float = 1.05,
+    permutation_p: float = 0.018,
+    crisis_dd: float = 0.21,
+    trend_dd: float = 0.08,
+    range_dd: float = 0.04,
+    age_days: float = 0.0,
+    generated_at: str | None = None,
+    filename: str = "evidence.md",
+) -> Path:
+    now = datetime.now(timezone.utc) - timedelta(days=age_days)
+    ts = generated_at or now.isoformat()
+
+    content = textwrap.dedent(f"""\
+        ---
+        generated_at: {ts}
+        walk_forward_period: "2025-04 to 2026-04"
+        metrics:
+          net_sharpe: {net_sharpe}
+          gross_sharpe: {gross_sharpe}
+          dsr: {dsr}
+          bootstrap_ci_lower: {bootstrap_ci_lower}
+          bootstrap_ci_upper: {bootstrap_ci_upper}
+          permutation_p: {permutation_p}
+          max_regime_dd:
+            trend: {trend_dd}
+            range: {range_dd}
+            crisis: {crisis_dd}
+        ---
+
+        # Strategy Evidence Pack
+        Body text here.
+    """)
+    p = tmp_path / filename
+    p.write_text(content)
+    return p
+
+
+def _gate(pack: Path, **kwargs) -> LiveSignalGate:
+    return LiveSignalGate(evidence_pack=pack, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Case 1: All thresholds pass
+# ---------------------------------------------------------------------------
+
+def test_gate_passes_all_thresholds(tmp_path):
+    pack = _make_pack(tmp_path)
+    result = _gate(pack).check()
+    assert result.passed is True
+    assert result.failures == []
+    assert result.evidence_pack_path == pack
+    assert result.evidence_pack_age_days < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Case 2: net_sharpe too low
+# ---------------------------------------------------------------------------
+
+def test_gate_fails_net_sharpe(tmp_path):
+    pack = _make_pack(tmp_path, net_sharpe=0.40)
+    result = _gate(pack).check()
+    assert result.passed is False
+    assert any("net_sharpe" in f for f in result.failures)
+
+
+# ---------------------------------------------------------------------------
+# Case 3: DSR too low
+# ---------------------------------------------------------------------------
+
+def test_gate_fails_dsr(tmp_path):
+    pack = _make_pack(tmp_path, dsr=-0.05)
+    result = _gate(pack).check()
+    assert result.passed is False
+    assert any("dsr" in f for f in result.failures)
+
+
+# ---------------------------------------------------------------------------
+# Case 4: bootstrap CI lower too low
+# ---------------------------------------------------------------------------
+
+def test_gate_fails_bootstrap_ci_lower(tmp_path):
+    pack = _make_pack(tmp_path, bootstrap_ci_lower=-0.10)
+    result = _gate(pack).check()
+    assert result.passed is False
+    assert any("bootstrap_ci_lower" in f for f in result.failures)
+
+
+# ---------------------------------------------------------------------------
+# Case 5: permutation p too high
+# ---------------------------------------------------------------------------
+
+def test_gate_fails_permutation_p(tmp_path):
+    pack = _make_pack(tmp_path, permutation_p=0.12)
+    result = _gate(pack).check()
+    assert result.passed is False
+    assert any("permutation_p" in f for f in result.failures)
+
+
+# ---------------------------------------------------------------------------
+# Case 6: regime DD too high (crisis)
+# ---------------------------------------------------------------------------
+
+def test_gate_fails_regime_dd(tmp_path):
+    pack = _make_pack(tmp_path, crisis_dd=0.35)
+    result = _gate(pack).check()
+    assert result.passed is False
+    assert any("max_regime_dd" in f and "crisis" in f for f in result.failures)
+
+
+# ---------------------------------------------------------------------------
+# Case 7: Evidence pack too old
+# ---------------------------------------------------------------------------
+
+def test_gate_fails_age_expired(tmp_path):
+    pack = _make_pack(tmp_path, age_days=31.0)
+    result = _gate(pack, max_evidence_age_days=30.0).check()
+    assert result.passed is False
+    assert any("days old" in f for f in result.failures)
+
+
+# ---------------------------------------------------------------------------
+# Case 8: Evidence pack file missing
+# ---------------------------------------------------------------------------
+
+def test_gate_fails_missing_file(tmp_path):
+    missing = tmp_path / "nonexistent.md"
+    result = _gate(missing).check()
+    assert result.passed is False
+    assert any("not found" in f for f in result.failures)
+
+
+# ---------------------------------------------------------------------------
+# Case 9: Multiple simultaneous failures reported
+# ---------------------------------------------------------------------------
+
+def test_gate_reports_multiple_failures(tmp_path):
+    pack = _make_pack(tmp_path, net_sharpe=0.1, dsr=-1.0, permutation_p=0.99)
+    result = _gate(pack).check()
+    assert result.passed is False
+    # At least 3 distinct failures
+    assert len(result.failures) >= 3
+
+
+# ---------------------------------------------------------------------------
+# Case 10: Missing metrics key
+# ---------------------------------------------------------------------------
+
+def test_gate_fails_missing_metric_key(tmp_path):
+    content = textwrap.dedent("""\
+        ---
+        generated_at: 2026-04-27T10:00:00+00:00
+        walk_forward_period: "2025-04 to 2026-04"
+        metrics:
+          gross_sharpe: 0.80
+        ---
+        Body.
+    """)
+    pack = tmp_path / "sparse.md"
+    pack.write_text(content)
+    result = _gate(pack).check()
+    assert result.passed is False
+    # Should flag multiple missing keys
+    missing_flags = [f for f in result.failures if "missing" in f]
+    assert len(missing_flags) >= 2
+
+
+# ---------------------------------------------------------------------------
+# Case 11: Alerter called on failure
+# ---------------------------------------------------------------------------
+
+def test_gate_calls_alerter_on_failure(tmp_path):
+    pack = _make_pack(tmp_path, net_sharpe=0.1)
+    alerter = MagicMock()
+    result = _gate(pack, alerter=alerter).check()
+    assert result.passed is False
+    alerter.send_alert.assert_called_once()
+    call_kwargs = alerter.send_alert.call_args
+    assert call_kwargs[1].get("level") == "CRITICAL" or (
+        len(call_kwargs[0]) >= 2 and call_kwargs[0][1] == "CRITICAL"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 12: Malformed frontmatter
+# ---------------------------------------------------------------------------
+
+def test_gate_fails_malformed_frontmatter(tmp_path):
+    content = "No frontmatter at all\njust body text\n"
+    pack = tmp_path / "bad.md"
+    pack.write_text(content)
+    result = _gate(pack).check()
+    assert result.passed is False
+    assert any("frontmatter" in f.lower() or "parse" in f.lower() for f in result.failures)
+
+
+# ---------------------------------------------------------------------------
+# Custom thresholds override
+# ---------------------------------------------------------------------------
+
+def test_gate_custom_thresholds_pass(tmp_path):
+    # Lower bar: net_sharpe threshold 0.3 instead of 0.5
+    pack = _make_pack(tmp_path, net_sharpe=0.40)
+    result = _gate(pack, thresholds={"min_sharpe_net": 0.3}).check()
+    assert result.passed is True
+
+
+def test_gate_custom_thresholds_fail(tmp_path):
+    # Raise bar: require net_sharpe > 0.8
+    pack = _make_pack(tmp_path, net_sharpe=0.65)
+    result = _gate(pack, thresholds={"min_sharpe_net": 0.8}).check()
+    assert result.passed is False
+
+
+# ---------------------------------------------------------------------------
+# Age boundary: exactly at limit should fail (> not >=)
+# ---------------------------------------------------------------------------
+
+def test_gate_age_exactly_at_limit_fails(tmp_path):
+    pack = _make_pack(tmp_path, age_days=30.01)
+    result = _gate(pack, max_evidence_age_days=30.0).check()
+    assert result.passed is False
+
+
+def test_gate_age_under_limit_passes_age_check(tmp_path):
+    pack = _make_pack(tmp_path, age_days=5.0)
+    # All other metrics good, only age check matters here
+    result = _gate(pack, max_evidence_age_days=30.0).check()
+    assert result.passed is True


### PR DESCRIPTION
## Summary

- `deployment/governance/live_signal_gate.py` — `LiveSignalGate` class: `strategy_evidence_v1.md` YAML frontmatter 파싱 → 6개 threshold 검증 (net Sharpe, DSR, bootstrap CI lower, permutation p, regime DD, evidence age)
- `scripts/check_signal_gate.py` — operator 단독 실행 wrapper (exit 0 = GO, 2 = FAIL, 1 = error)
- `scripts/run_paper_trader.py` — `--exchange-mode live` 진입 시 gate 자동 실행, fail이면 즉시 exit 2 (live 차단)
- `config/deployment.yaml` — `live_signal_gate:` 섹션 추가 (thresholds + evidence pack 경로)
- `docs/runbook/go_live_checklist.md` — Track Z (Z1–Z4) 추가 (code-enforced gate)

## Test plan

- [x] `tests/deployment/governance/test_live_signal_gate.py` — 16 cases: pass / sharpe 미달 / DSR 미달 / CI lower 미달 / permutation p 초과 / regime DD 초과 / age 만료 / evidence pack 없음 / 복수 실패 / missing key / alerter 호출 / malformed frontmatter / custom thresholds / age boundary
- [x] `python -m pytest -q` — 2573 passed, 27 skipped, 0 new failures
- [x] `python scripts/check_signal_gate.py --config config/deployment.yaml` → exit 2 (simulated evidence pack 기준 예상 동작)

## Pre-condition & context

- **depends-on: A0 GO** — 실 walk-forward 결과가 들어와야 gate가 PASS됨
- A0 완료 전까지 `--exchange-mode live` 진입은 코드 레벨에서 차단됨
- Phase 8 Restructured plan Track A (A0.5), Week 89

🤖 Generated with [Claude Code](https://claude.com/claude-code)