### PR TITLE
[A6] Cost decomposition dashboard — 4-axis P&L breakdown + daily report

### DIFF
--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -72,3 +72,15 @@ llm_review:
     downside_risk: 0.15
     drawdown: 0.15
     transaction_cost: 0.10
+
+# ── A6 Cost Decomposition (Week 90) ──────────────────────────
+# 4-axis P&L breakdown: signal / slippage / fee / funding
+# audit_log path is read by generate_daily_cost_report.py and
+# the CostDecomposer.from_audit_log() factory.
+cost_decomposition:
+  audit_log: "audit_log/audit.jsonl"
+  output_dir: "docs/reports"
+  # Set true only when trading perpetual futures (funding payments tracked)
+  enable_funding_tracking: false
+  # launchd schedule: 00:30 UTC daily (see deployment/launchd/*.plist)
+  report_schedule_utc: "00:30"

--- a/deployment/analysis/cost_decomposition.py
+++ b/deployment/analysis/cost_decomposition.py
@@ -1,0 +1,392 @@
+"""
+A6 Cost Decomposition — 4-axis P&L breakdown (Week 90).
+
+Decomposes each fill's P&L into four additive components:
+
+    total_pnl = signal_pnl + slippage_pnl + fee_pnl + funding_pnl
+
+Where:
+    signal_pnl    — strategy alpha: (mid_at_submit - entry_price) * qty  [sells only]
+    slippage_pnl  — execution friction vs mid: (fill_price - mid_at_submit) * qty * side_sign
+    fee_pnl       — -fee_paid
+    funding_pnl   — -funding_accrued  (perps; 0 for spot)
+
+Algebraic identity check:
+    signal_pnl + slippage_pnl = (fill_price - entry_price) * qty  [for sells]
+    → total_pnl = (fill_price - entry_price) * qty - fee - funding  [net realized PnL]
+
+For buys (position-opening):
+    signal_pnl = 0  (no realized PnL yet)
+    slippage_pnl = -(fill_price - mid_at_submit) * qty  (cost if fill > mid)
+
+Usage:
+    from deployment.analysis.cost_decomposition import FillRecord, decompose, CostDecomposer
+
+    fill = FillRecord(
+        fill_id="f001",
+        timestamp=datetime.utcnow(),
+        side="sell",
+        fill_price=110.0,
+        qty=1.0,
+        entry_price=100.0,
+        mid_at_submit=109.5,
+    )
+    d = decompose(fill, fee_paid=0.11)
+    # d.total_pnl == d.signal_pnl + d.slippage_pnl + d.fee_pnl + d.funding_pnl
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FillRecord:
+    """Input descriptor for a single fill (buy or sell)."""
+    fill_id: str
+    timestamp: datetime
+    side: str           # "buy" | "sell"
+    fill_price: float
+    qty: float
+    entry_price: float  # 0.0 for buys (unrealized); used only for sells
+    mid_at_submit: float  # mid-market price at decision time; use fill_price if unknown
+
+
+@dataclass
+class FillDecomposition:
+    """4-axis P&L decomposition for a single fill."""
+    fill_id: str
+    timestamp: datetime
+    signal_pnl: float       # strategy alpha (sells only; 0 for buys)
+    slippage_pnl: float     # execution friction vs mid
+    fee_pnl: float          # -fee_paid  (always ≤ 0)
+    funding_pnl: float      # -funding_accrued (always ≤ 0 for longs)
+    total_pnl: float        # algebraic sum of the four axes
+
+    def to_dict(self) -> Dict:
+        d = asdict(self)
+        d["timestamp"] = self.timestamp.isoformat()
+        return d
+
+
+@dataclass
+class DailyCostSummary:
+    """Aggregate 4-axis breakdown for a single calendar day."""
+    date: date
+    num_fills: int
+    num_sells: int
+    total_signal_pnl: float
+    total_slippage_pnl: float
+    total_fee_pnl: float
+    total_funding_pnl: float
+    total_pnl: float
+    avg_slippage_per_fill: float   # average |slippage_pnl| per fill
+
+
+@dataclass
+class CumulativeCostSummary:
+    """Running totals across all tracked fills."""
+    num_fills: int
+    num_sells: int
+    total_signal_pnl: float
+    total_slippage_pnl: float
+    total_fee_pnl: float
+    total_funding_pnl: float
+    total_pnl: float
+    avg_slippage_per_fill: float
+
+
+# ---------------------------------------------------------------------------
+# Core decomposition function
+# ---------------------------------------------------------------------------
+
+def decompose(
+    fill: FillRecord,
+    fee_paid: float,
+    funding_accrued: float = 0.0,
+) -> FillDecomposition:
+    """Decompose a single fill into 4 P&L axes.
+
+    Parameters
+    ----------
+    fill :
+        FillRecord with fill_price, mid_at_submit, entry_price, side.
+    fee_paid :
+        Total fee paid on this fill (positive number; stored as negative fee_pnl).
+    funding_accrued :
+        Funding payment accrued on this fill's notional (positive = cost).
+        Pass 0.0 for spot (default).
+
+    Returns
+    -------
+    FillDecomposition
+        Decomposes P&L into signal / slippage / fee / funding axes.
+        total_pnl is guaranteed to equal the algebraic sum.
+    """
+    if fill.side == "sell":
+        # Strategy alpha: what the signal would have earned at mid
+        signal_pnl = (fill.mid_at_submit - fill.entry_price) * fill.qty
+        # Execution quality: improvement or degradation vs mid
+        slippage_pnl = (fill.fill_price - fill.mid_at_submit) * fill.qty
+    else:
+        # Buy: no realized signal PnL yet; slippage is the cost above mid
+        signal_pnl = 0.0
+        slippage_pnl = -(fill.fill_price - fill.mid_at_submit) * fill.qty
+
+    fee_pnl = -float(fee_paid)
+    funding_pnl = -float(funding_accrued)
+    total_pnl = signal_pnl + slippage_pnl + fee_pnl + funding_pnl
+
+    return FillDecomposition(
+        fill_id=fill.fill_id,
+        timestamp=fill.timestamp,
+        signal_pnl=signal_pnl,
+        slippage_pnl=slippage_pnl,
+        fee_pnl=fee_pnl,
+        funding_pnl=funding_pnl,
+        total_pnl=total_pnl,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CostDecomposer — accumulates fills and produces summaries
+# ---------------------------------------------------------------------------
+
+class CostDecomposer:
+    """Accumulates FillDecomposition objects and produces daily/cumulative summaries.
+
+    Thread-safety: not thread-safe; wrap in a lock if calling from multiple threads.
+    """
+
+    def __init__(self) -> None:
+        self._fills: List[FillDecomposition] = []
+
+    # ------------------------------------------------------------------
+    # Ingestion
+    # ------------------------------------------------------------------
+
+    def add(self, decomp: FillDecomposition) -> None:
+        """Append a pre-computed FillDecomposition."""
+        self._fills.append(decomp)
+
+    def add_fill(
+        self,
+        fill: FillRecord,
+        fee_paid: float,
+        funding_accrued: float = 0.0,
+    ) -> FillDecomposition:
+        """Decompose and accumulate a fill in one step. Returns the FillDecomposition."""
+        d = decompose(fill, fee_paid=fee_paid, funding_accrued=funding_accrued)
+        self._fills.append(d)
+        return d
+
+    # ------------------------------------------------------------------
+    # Summaries
+    # ------------------------------------------------------------------
+
+    def daily_summary(self, target_date: date) -> Optional[DailyCostSummary]:
+        """Aggregate fills for a specific calendar day (UTC date)."""
+        day_fills = [
+            f for f in self._fills
+            if f.timestamp.date() == target_date
+        ]
+        if not day_fills:
+            return None
+        return self._summarise_day(target_date, day_fills)
+
+    def all_daily_summaries(self) -> List[DailyCostSummary]:
+        """Return one DailyCostSummary per calendar day that has fills."""
+        by_date: Dict[date, List[FillDecomposition]] = defaultdict(list)
+        for f in self._fills:
+            by_date[f.timestamp.date()].append(f)
+        return [
+            self._summarise_day(d, fills)
+            for d, fills in sorted(by_date.items())
+        ]
+
+    def cumulative_summary(self) -> CumulativeCostSummary:
+        """Running totals across all tracked fills."""
+        fills = self._fills
+        n = len(fills)
+        n_sells = sum(1 for f in fills if f.slippage_pnl != 0 or f.signal_pnl != 0)
+        total_signal = sum(f.signal_pnl for f in fills)
+        total_slip = sum(f.slippage_pnl for f in fills)
+        total_fee = sum(f.fee_pnl for f in fills)
+        total_fund = sum(f.funding_pnl for f in fills)
+        total = sum(f.total_pnl for f in fills)
+        avg_slip = abs(total_slip) / n if n > 0 else 0.0
+        return CumulativeCostSummary(
+            num_fills=n,
+            num_sells=n_sells,
+            total_signal_pnl=total_signal,
+            total_slippage_pnl=total_slip,
+            total_fee_pnl=total_fee,
+            total_funding_pnl=total_fund,
+            total_pnl=total,
+            avg_slippage_per_fill=avg_slip,
+        )
+
+    def fills(self) -> List[FillDecomposition]:
+        """Read-only view of accumulated fills."""
+        return list(self._fills)
+
+    # ------------------------------------------------------------------
+    # Factory: load from audit.jsonl
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_audit_log(
+        cls,
+        path: Path,
+        enable_funding: bool = False,
+        mid_price_key: str = "mid_price",
+    ) -> "CostDecomposer":
+        """Build a CostDecomposer by replaying fill records from an audit log.
+
+        Expected audit.jsonl record format (type=="fill"):
+            {
+              "ts": "2026-04-28T00:01:00Z",
+              "type": "fill",
+              "payload": {
+                "fill_id": "f001",          # optional; derived from ts if absent
+                "side": "buy"|"sell",
+                "price": 65000.0,           # fill_price
+                "mid_price": 64990.0,       # optional; defaults to price
+                "quantity": 0.001,
+                "fee": 6.5,
+                "pnl": 0.0,                 # gross market move (sells only)
+                "entry_price": 60000.0,     # optional; inferred from pnl if absent
+                "funding": 0.0              # optional; only if enable_funding=True
+              }
+            }
+        """
+        decomposer = cls()
+        path = Path(path)
+        if not path.exists():
+            logger.warning("audit log not found: %s", path)
+            return decomposer
+
+        _buy_prices: Dict[str, float] = {}  # symbol → last buy fill_price (for entry_price inference)
+        n_skipped = 0
+
+        with open(path, encoding="utf-8") as fh:
+            for lineno, line in enumerate(fh, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.debug("audit log line %d: JSON parse error, skipping", lineno)
+                    n_skipped += 1
+                    continue
+
+                if record.get("type") != "fill":
+                    continue
+
+                payload = record.get("payload", {})
+                try:
+                    ts_str = record.get("ts", "")
+                    ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                    side = payload["side"]
+                    fill_price = float(payload["price"])
+                    qty = float(payload["quantity"])
+                    fee = float(payload.get("fee", 0.0))
+                    mid = float(payload.get(mid_price_key, fill_price))
+                    fill_id = payload.get("fill_id", f"fill_{lineno}")
+                    funding = float(payload.get("funding", 0.0)) if enable_funding else 0.0
+
+                    # Infer entry_price for sells
+                    if side == "sell":
+                        gross_pnl = float(payload.get("pnl", 0.0))
+                        entry_price_raw = float(payload.get("entry_price", 0.0))
+                        if entry_price_raw > 0:
+                            entry_price = entry_price_raw
+                        elif abs(qty) > 1e-10 and gross_pnl != 0.0:
+                            # pnl = (fill_price - entry_price) * qty → entry = fill - pnl/qty
+                            entry_price = fill_price - gross_pnl / qty
+                        else:
+                            entry_price = _buy_prices.get("_last", fill_price)
+                    else:
+                        entry_price = 0.0
+                        _buy_prices["_last"] = fill_price
+
+                    fill = FillRecord(
+                        fill_id=fill_id,
+                        timestamp=ts,
+                        side=side,
+                        fill_price=fill_price,
+                        qty=qty,
+                        entry_price=entry_price,
+                        mid_at_submit=mid,
+                    )
+                    decomposer.add_fill(fill, fee_paid=fee, funding_accrued=funding)
+
+                except (KeyError, ValueError) as exc:
+                    logger.debug("audit log line %d: parse error %s, skipping", lineno, exc)
+                    n_skipped += 1
+
+        logger.info(
+            "CostDecomposer loaded %d fills from %s (%d skipped)",
+            len(decomposer._fills), path, n_skipped,
+        )
+        return decomposer
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _summarise_day(
+        target_date: date,
+        fills: Iterable[FillDecomposition],
+    ) -> DailyCostSummary:
+        fills_list = list(fills)
+        n = len(fills_list)
+        n_sells = sum(1 for f in fills_list if f.signal_pnl != 0.0 or (f.slippage_pnl != 0 and f.signal_pnl == 0))
+        total_signal = sum(f.signal_pnl for f in fills_list)
+        total_slip = sum(f.slippage_pnl for f in fills_list)
+        total_fee = sum(f.fee_pnl for f in fills_list)
+        total_fund = sum(f.funding_pnl for f in fills_list)
+        total = sum(f.total_pnl for f in fills_list)
+        avg_slip = abs(total_slip) / n if n > 0 else 0.0
+        return DailyCostSummary(
+            date=target_date,
+            num_fills=n,
+            num_sells=n_sells,
+            total_signal_pnl=total_signal,
+            total_slippage_pnl=total_slip,
+            total_fee_pnl=total_fee,
+            total_funding_pnl=total_fund,
+            total_pnl=total,
+            avg_slippage_per_fill=avg_slip,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def verify_decomposition_identity(
+    decomp: FillDecomposition,
+    realized_pnl: float,
+    tol: float = 0.01,
+) -> bool:
+    """Return True if 4-axis sum matches realized_pnl within tol dollars.
+
+    Used for regression testing (A6.5).
+    """
+    computed = decomp.signal_pnl + decomp.slippage_pnl + decomp.fee_pnl + decomp.funding_pnl
+    return abs(computed - realized_pnl) < tol and abs(decomp.total_pnl - realized_pnl) < tol

--- a/deployment/launchd/com.tradingbot.daily-cost-report.plist
+++ b/deployment/launchd/com.tradingbot.daily-cost-report.plist
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  A6 Daily Cost Report — launchd plist (Week 90)
+
+  Runs generate_daily_cost_report.py at 00:30 UTC every day.
+  macOS local time offset must be accounted for:
+    UTC 00:30  =  19:30 PDT (UTC-7)  =  20:30 PST (UTC-8)
+
+  Installation (run once):
+    cp deployment/launchd/com.tradingbot.daily-cost-report.plist \
+        ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.tradingbot.daily-cost-report.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.tradingbot.daily-cost-report.plist
+    rm ~/Library/LaunchAgents/com.tradingbot.daily-cost-report.plist
+
+  Manual test run:
+    launchctl start com.tradingbot.daily-cost-report
+
+  IMPORTANT: Update WorkingDirectory and the python path if the repo is moved.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.tradingbot.daily-cost-report</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <!-- Use the project-specific Python interpreter -->
+        <string>/Users/skylar/anaconda3/bin/python</string>
+        <string>scripts/generate_daily_cost_report.py</string>
+    </array>
+
+    <!-- Working directory = repo root so relative paths resolve correctly -->
+    <key>WorkingDirectory</key>
+    <string>/Users/skylar/Desktop/trading_bot</string>
+
+    <!--
+      00:30 UTC daily.
+      Adjust Hour/Minute for your local timezone:
+        PDT (UTC-7): Hour=17, Minute=30
+        PST (UTC-8): Hour=16, Minute=30
+      Using UTC-7 (PDT) as the default here.
+    -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>17</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/tradingbot-daily-cost-report.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/tradingbot-daily-cost-report.err</string>
+
+    <!-- Re-run ASAP if it misses its window (e.g. laptop was sleeping) -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>

--- a/deployment/monitoring/dashboard.py
+++ b/deployment/monitoring/dashboard.py
@@ -4,6 +4,8 @@ Minimal HTTP dashboard for real-time trading metrics.
 Serves:
   GET /metrics          → JSON snapshot of current trading state
   GET /metrics/history  → JSON array of recent snapshots (last 100)
+  GET /model-drift      → ModelDriftDetector snapshot (A5; disabled if not wired)
+  GET /cost-breakdown   → CostDecomposer cumulative 4-axis summary (A6; disabled if not wired)
   GET /health           → {"status": "ok"}
 
 Usage:
@@ -26,6 +28,7 @@ def start_dashboard(
     metrics_exporter,
     port: int = 8080,
     model_drift_detector=None,
+    cost_decomposer=None,
 ) -> threading.Thread:
     """Start dashboard HTTP server in a daemon thread.
 
@@ -34,6 +37,8 @@ def start_dashboard(
         port: HTTP port (default 8080)
         model_drift_detector: Optional ModelDriftDetector (A5). When supplied,
             exposes a ``/model-drift`` endpoint with current snapshot.
+        cost_decomposer: Optional CostDecomposer (A6). When supplied,
+            exposes a ``/cost-breakdown`` endpoint with cumulative 4-axis summary.
 
     Returns:
         threading.Thread: The daemon thread running the server
@@ -60,6 +65,36 @@ def start_dashboard(
             elif self.path == "/model-drift":
                 if model_drift_detector is not None:
                     self._json_response(200, model_drift_detector.snapshot())
+                else:
+                    self._json_response(200, {"status": "disabled"})
+            elif self.path == "/cost-breakdown":
+                if cost_decomposer is not None:
+                    summary = cost_decomposer.cumulative_summary()
+                    daily = cost_decomposer.all_daily_summaries()
+                    data = {
+                        "cumulative": {
+                            "num_fills": summary.num_fills,
+                            "total_signal_pnl": summary.total_signal_pnl,
+                            "total_slippage_pnl": summary.total_slippage_pnl,
+                            "total_fee_pnl": summary.total_fee_pnl,
+                            "total_funding_pnl": summary.total_funding_pnl,
+                            "total_pnl": summary.total_pnl,
+                            "avg_slippage_per_fill": summary.avg_slippage_per_fill,
+                        },
+                        "daily": [
+                            {
+                                "date": str(s.date),
+                                "num_fills": s.num_fills,
+                                "total_signal_pnl": s.total_signal_pnl,
+                                "total_slippage_pnl": s.total_slippage_pnl,
+                                "total_fee_pnl": s.total_fee_pnl,
+                                "total_funding_pnl": s.total_funding_pnl,
+                                "total_pnl": s.total_pnl,
+                            }
+                            for s in daily
+                        ],
+                    }
+                    self._json_response(200, data)
                 else:
                     self._json_response(200, {"status": "disabled"})
             elif self.path == "/health":

--- a/deployment/paper_trader.py
+++ b/deployment/paper_trader.py
@@ -685,9 +685,10 @@ class PaperTrader:
         if cost > self.state.pos.cash:
             return
         self.state.pos.apply_buy(quantity=quantity, price=price, fee=fee)
+        _buy_ts = datetime.utcnow()
         self.state.trades.append(
             Trade(
-                timestamp=datetime.utcnow(),
+                timestamp=_buy_ts,
                 side="buy",
                 price=price,
                 quantity=quantity,
@@ -695,6 +696,18 @@ class PaperTrader:
             )
         )
         logger.debug("BUY qty=%.6f price=%.2f fee=%.4f", quantity, price, fee)
+        # A6: log fill to audit chain for cost decomposition
+        if self.audit_logger is not None:
+            self.audit_logger.log_fill({
+                "fill_id": f"buy_{_buy_ts.strftime('%Y%m%dT%H%M%S%f')}",
+                "side": "buy",
+                "price": price,
+                "mid_price": price,
+                "quantity": quantity,
+                "fee": fee,
+                "pnl": 0.0,
+                "entry_price": 0.0,
+            })
 
         if self.order_manager is not None:
             try:
@@ -721,10 +734,12 @@ class PaperTrader:
         if sell_qty < 1e-8:
             return
         fee = sell_qty * price * self.trading_fee
+        _entry_price = self.state.pos.entry_price  # capture before apply_sell clears it
         pnl = self.state.pos.apply_sell(quantity=sell_qty, price=price, fee=fee)
+        _sell_ts = datetime.utcnow()
         self.state.trades.append(
             Trade(
-                timestamp=datetime.utcnow(),
+                timestamp=_sell_ts,
                 side="sell",
                 price=price,
                 quantity=sell_qty,
@@ -733,6 +748,18 @@ class PaperTrader:
             )
         )
         logger.debug("SELL qty=%.6f price=%.2f pnl=%.4f", sell_qty, price, pnl)
+        # A6: log fill to audit chain for cost decomposition
+        if self.audit_logger is not None:
+            self.audit_logger.log_fill({
+                "fill_id": f"sell_{_sell_ts.strftime('%Y%m%dT%H%M%S%f')}",
+                "side": "sell",
+                "price": price,
+                "mid_price": price,
+                "quantity": sell_qty,
+                "fee": fee,
+                "pnl": pnl,
+                "entry_price": _entry_price,
+            })
 
         if self.order_manager is not None:
             try:

--- a/docs/phase8/cost_decomposition.md
+++ b/docs/phase8/cost_decomposition.md
@@ -1,0 +1,108 @@
+# A6 Cost Decomposition Dashboard
+
+**Phase 8 Week 90 — P&L 4-axis breakdown + daily report**
+
+## Overview
+
+Real P&L = signal P&L + slippage P&L + fee P&L + funding P&L.
+
+When live P&L goes negative, this decomposition identifies *which axis* is the cause — essential for debugging before the issue compounds.
+
+| Axis | Formula | Notes |
+|------|---------|-------|
+| **Signal P&L** | `(mid_at_submit − entry_price) × qty` | Pure strategy alpha; what you'd earn filling at mid |
+| **Slippage P&L** | `(fill_price − mid_at_submit) × qty` | Execution quality vs mid (negative = worse) |
+| **Fee P&L** | `−fee_paid` | Always ≤ 0 |
+| **Funding P&L** | `−funding_accrued` | Perps only; 0 for spot (config flag) |
+| **Total P&L** | Sum of above | Algebraic identity guaranteed |
+
+**Regression guarantee (A6.5)**: `|4-axis sum − realized P&L| < $0.01` per fill.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| [`deployment/analysis/cost_decomposition.py`](../../deployment/analysis/cost_decomposition.py) | Core module: `FillRecord`, `FillDecomposition`, `decompose()`, `CostDecomposer` |
+| [`scripts/generate_daily_cost_report.py`](../../scripts/generate_daily_cost_report.py) | CLI: reads `audit_log/audit.jsonl` → `docs/reports/cost_breakdown_{date}.md` |
+| [`deployment/launchd/com.tradingbot.daily-cost-report.plist`](../../deployment/launchd/com.tradingbot.daily-cost-report.plist) | macOS launchd: 00:30 UTC daily |
+| [`tests/deployment/analysis/test_cost_decomposition.py`](../../tests/deployment/analysis/test_cost_decomposition.py) | 25 unit + regression tests |
+
+## Dashboard
+
+`GET /cost-breakdown` on the live dashboard (port 8080) returns cumulative and per-day JSON:
+
+```json
+{
+  "cumulative": {
+    "num_fills": 42,
+    "total_signal_pnl": 128.50,
+    "total_slippage_pnl": -3.20,
+    "total_fee_pnl": -12.60,
+    "total_funding_pnl": 0.0,
+    "total_pnl": 112.70
+  },
+  "daily": [...]
+}
+```
+
+Wire it in by passing `cost_decomposer=<CostDecomposer instance>` to `start_dashboard()`.
+
+## Audit Log Fill Format
+
+`paper_trader.py` now writes fill records to `audit_log/audit.jsonl` on every buy/sell:
+
+```json
+{
+  "ts": "2026-04-28T12:00:01.234Z",
+  "type": "fill",
+  "payload": {
+    "fill_id": "sell_20260428T120001234000",
+    "side": "sell",
+    "price": 65000.0,
+    "mid_price": 65000.0,
+    "quantity": 0.001,
+    "fee": 6.5,
+    "pnl": 20.0,
+    "entry_price": 45000.0
+  },
+  "hash": "..."
+}
+```
+
+## Running the Report Manually
+
+```bash
+# Yesterday's report (default)
+python scripts/generate_daily_cost_report.py
+
+# Specific date
+python scripts/generate_daily_cost_report.py --date 2026-04-27
+
+# All dates with fills
+python scripts/generate_daily_cost_report.py --all-time
+
+# With funding (perps)
+python scripts/generate_daily_cost_report.py --enable-funding
+```
+
+## Config
+
+`config/deployment.yaml`:
+
+```yaml
+cost_decomposition:
+  audit_log: "audit_log/audit.jsonl"
+  output_dir: "docs/reports"
+  enable_funding_tracking: false   # set true for perps
+  report_schedule_utc: "00:30"
+```
+
+## launchd Setup
+
+```bash
+cp deployment/launchd/com.tradingbot.daily-cost-report.plist \
+    ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.tradingbot.daily-cost-report.plist
+```
+
+**Note**: Hour/Minute in the plist is set for PDT (UTC-7). Adjust for your timezone.

--- a/scripts/generate_daily_cost_report.py
+++ b/scripts/generate_daily_cost_report.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+A6 Daily Cost Report generator (Week 90).
+
+Reads fills from audit_log/audit.jsonl and writes a 4-axis P&L breakdown
+to docs/reports/cost_breakdown_{date}.md.
+
+Usage:
+    python scripts/generate_daily_cost_report.py
+    python scripts/generate_daily_cost_report.py --date 2026-04-27
+    python scripts/generate_daily_cost_report.py --audit-log audit_log/audit.jsonl \\
+        --output-dir docs/reports --date 2026-04-28
+
+Scheduled via launchd (00:30 UTC daily).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+# Resolve repo root so this script works from any cwd.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from deployment.analysis.cost_decomposition import CostDecomposer, DailyCostSummary
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Report rendering
+# ---------------------------------------------------------------------------
+
+def _bar(value: float, total: float, width: int = 20) -> str:
+    """ASCII bar proportional to |value / total|."""
+    if abs(total) < 1e-10:
+        return " " * width
+    frac = min(abs(value / total), 1.0)
+    filled = int(frac * width)
+    return "█" * filled + "░" * (width - filled)
+
+
+def render_daily_report(
+    summary: DailyCostSummary,
+    cumulative_summary,
+    target_date: date,
+    generated_at: datetime,
+) -> str:
+    """Render a markdown cost breakdown report."""
+    lines: list[str] = []
+
+    lines.append(f"# Daily Cost Report — {target_date.isoformat()}")
+    lines.append("")
+    lines.append(f"*Generated: {generated_at.strftime('%Y-%m-%dT%H:%M:%SZ')}*")
+    lines.append("")
+
+    # ── Today ──────────────────────────────────────────────────────────────
+    lines.append("## Today's 4-Axis P&L Breakdown")
+    lines.append("")
+    lines.append(f"| Axis | Amount ($) | Share |")
+    lines.append(f"|------|-----------|-------|")
+
+    total_abs = abs(summary.total_pnl) if abs(summary.total_pnl) > 1e-10 else 1.0
+    rows = [
+        ("Signal P&L", summary.total_signal_pnl, "strategy alpha"),
+        ("Slippage P&L", summary.total_slippage_pnl, "execution friction"),
+        ("Fee P&L", summary.total_fee_pnl, "transaction costs"),
+        ("Funding P&L", summary.total_funding_pnl, "funding / perps"),
+    ]
+    for label, val, note in rows:
+        pct = val / total_abs * 100 if total_abs > 1e-10 else 0.0
+        lines.append(f"| {label} | `{val:+.4f}` | {pct:+.1f}% — {note} |")
+
+    lines.append(f"| **Total P&L** | **`{summary.total_pnl:+.4f}`** | 100% |")
+    lines.append("")
+
+    # ASCII stacked bar
+    lines.append("### Visual breakdown")
+    lines.append("")
+    lines.append("```")
+    for label, val, _ in rows:
+        bar = _bar(val, total_abs)
+        sign = "+" if val >= 0 else "-"
+        lines.append(f"  {label:<14} [{bar}] {sign}${abs(val):.4f}")
+    lines.append("```")
+    lines.append("")
+
+    # Stats
+    lines.append("### Statistics")
+    lines.append("")
+    lines.append(f"- **Fills today**: {summary.num_fills}")
+    lines.append(f"- **Closing trades**: {summary.num_sells}")
+    lines.append(f"- **Avg slippage / fill**: ${summary.avg_slippage_per_fill:.4f}")
+    if summary.num_fills > 0 and abs(summary.total_signal_pnl) > 1e-10:
+        slip_pct = abs(summary.total_slippage_pnl) / abs(summary.total_signal_pnl) * 100
+        lines.append(f"- **Slippage as % of signal**: {slip_pct:.2f}%")
+    lines.append("")
+
+    # ── Cumulative ─────────────────────────────────────────────────────────
+    if cumulative_summary is not None:
+        lines.append("## Cumulative (since stage start)")
+        lines.append("")
+        lines.append(f"| Axis | Cumulative ($) |")
+        lines.append(f"|------|---------------|")
+        lines.append(f"| Signal P&L | `{cumulative_summary.total_signal_pnl:+.4f}` |")
+        lines.append(f"| Slippage P&L | `{cumulative_summary.total_slippage_pnl:+.4f}` |")
+        lines.append(f"| Fee P&L | `{cumulative_summary.total_fee_pnl:+.4f}` |")
+        lines.append(f"| Funding P&L | `{cumulative_summary.total_funding_pnl:+.4f}` |")
+        lines.append(f"| **Total P&L** | **`{cumulative_summary.total_pnl:+.4f}`** |")
+        lines.append("")
+        lines.append(f"*Total fills: {cumulative_summary.num_fills}*")
+        lines.append("")
+
+    # ── Regression check ───────────────────────────────────────────────────
+    lines.append("## Regression Check (A6.5)")
+    lines.append("")
+    computed = (
+        summary.total_signal_pnl
+        + summary.total_slippage_pnl
+        + summary.total_fee_pnl
+        + summary.total_funding_pnl
+    )
+    delta = abs(computed - summary.total_pnl)
+    status = "✅ PASS" if delta < 0.01 else "❌ FAIL"
+    lines.append(f"- 4-axis sum: `{computed:+.6f}`")
+    lines.append(f"- Stored total: `{summary.total_pnl:+.6f}`")
+    lines.append(f"- Δ: `{delta:.8f}` — **{status}** (threshold: $0.01)")
+    lines.append("")
+
+    lines.append("---")
+    lines.append("*A6 Cost Decomposition — Phase 8 Week 90*")
+
+    return "\n".join(lines)
+
+
+def render_empty_report(target_date: date, generated_at: datetime) -> str:
+    return (
+        f"# Daily Cost Report — {target_date.isoformat()}\n\n"
+        f"*Generated: {generated_at.strftime('%Y-%m-%dT%H:%M:%SZ')}*\n\n"
+        f"No fills found for {target_date.isoformat()}.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Generate daily A6 cost breakdown report")
+    p.add_argument(
+        "--date",
+        default=None,
+        help="Target date YYYY-MM-DD (default: yesterday UTC)",
+    )
+    p.add_argument(
+        "--audit-log",
+        default=str(_REPO_ROOT / "audit_log" / "audit.jsonl"),
+        help="Path to audit.jsonl",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=str(_REPO_ROOT / "docs" / "reports"),
+        help="Directory to write cost_breakdown_{date}.md",
+    )
+    p.add_argument(
+        "--enable-funding",
+        action="store_true",
+        default=False,
+        help="Parse funding_pnl from audit log (perps only)",
+    )
+    p.add_argument(
+        "--all-time",
+        action="store_true",
+        default=False,
+        help="Write reports for every date that has fills (not just target date)",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    now_utc = datetime.now(timezone.utc)
+
+    if args.date:
+        target_date = date.fromisoformat(args.date)
+    else:
+        # Default: yesterday UTC (report runs at 00:30 UTC for the completed day)
+        target_date = (now_utc - timedelta(days=1)).date()
+
+    audit_log_path = Path(args.audit_log)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Loading fills from %s", audit_log_path)
+    decomposer = CostDecomposer.from_audit_log(
+        audit_log_path,
+        enable_funding=args.enable_funding,
+    )
+
+    cumulative = decomposer.cumulative_summary() if decomposer.fills() else None
+
+    dates_to_report: list[date] = []
+    if args.all_time:
+        dates_to_report = [s.date for s in decomposer.all_daily_summaries()]
+        if not dates_to_report:
+            dates_to_report = [target_date]
+    else:
+        dates_to_report = [target_date]
+
+    reports_written = 0
+    for d in dates_to_report:
+        summary = decomposer.daily_summary(d)
+        if summary is not None:
+            content = render_daily_report(summary, cumulative, d, now_utc)
+        else:
+            content = render_empty_report(d, now_utc)
+
+        out_path = output_dir / f"cost_breakdown_{d.isoformat()}.md"
+        out_path.write_text(content, encoding="utf-8")
+        logger.info("Written: %s", out_path)
+        reports_written += 1
+
+    logger.info("Done — %d report(s) written to %s", reports_written, output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/deployment/analysis/test_cost_decomposition.py
+++ b/tests/deployment/analysis/test_cost_decomposition.py
@@ -1,0 +1,322 @@
+"""
+A6 Cost Decomposition tests (Week 90).
+
+Covers:
+  - decompose(): algebraic identity (total == sum of 4 axes)
+  - decompose(): sell signal_pnl matches (fill - entry) * qty
+  - decompose(): buy has zero signal_pnl
+  - decompose(): slippage direction (fill > mid → negative for buy)
+  - decompose(): fee_pnl and funding_pnl signs
+  - CostDecomposer: accumulation and daily summary
+  - CostDecomposer: cumulative summary totals
+  - CostDecomposer.from_audit_log(): parses fill records from JSONL
+  - Regression (A6.5): 4-axis sum matches realized P&L within $0.01
+  - verify_decomposition_identity() helper
+"""
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from deployment.analysis.cost_decomposition import (
+    CostDecomposer,
+    FillDecomposition,
+    FillRecord,
+    decompose,
+    verify_decomposition_identity,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ts(hour: int = 12, minute: int = 0) -> datetime:
+    return datetime(2026, 4, 28, hour, minute, 0, tzinfo=timezone.utc)
+
+
+def _sell_fill(
+    fill_price: float = 110.0,
+    entry_price: float = 100.0,
+    qty: float = 1.0,
+    mid: float = 109.5,
+    fill_id: str = "f_sell",
+    ts: datetime = None,
+) -> FillRecord:
+    return FillRecord(
+        fill_id=fill_id,
+        timestamp=ts or _ts(),
+        side="sell",
+        fill_price=fill_price,
+        qty=qty,
+        entry_price=entry_price,
+        mid_at_submit=mid,
+    )
+
+
+def _buy_fill(
+    fill_price: float = 100.5,
+    qty: float = 1.0,
+    mid: float = 100.0,
+    fill_id: str = "f_buy",
+    ts: datetime = None,
+) -> FillRecord:
+    return FillRecord(
+        fill_id=fill_id,
+        timestamp=ts or _ts(10),
+        side="buy",
+        fill_price=fill_price,
+        qty=qty,
+        entry_price=0.0,
+        mid_at_submit=mid,
+    )
+
+
+# ---------------------------------------------------------------------------
+# decompose(): algebraic identity
+# ---------------------------------------------------------------------------
+
+class TestDecomposeIdentity:
+    def test_sell_4axis_sum_equals_total_pnl(self):
+        """total_pnl must equal the algebraic sum of the 4 axes."""
+        fill = _sell_fill(fill_price=110.0, entry_price=100.0, qty=2.0, mid=109.0)
+        d = decompose(fill, fee_paid=0.22, funding_accrued=0.0)
+        assert abs(d.total_pnl - (d.signal_pnl + d.slippage_pnl + d.fee_pnl + d.funding_pnl)) < 1e-9
+
+    def test_buy_4axis_sum_equals_total_pnl(self):
+        fill = _buy_fill(fill_price=100.5, qty=1.0, mid=100.0)
+        d = decompose(fill, fee_paid=0.10)
+        assert abs(d.total_pnl - (d.signal_pnl + d.slippage_pnl + d.fee_pnl + d.funding_pnl)) < 1e-9
+
+    def test_with_funding(self):
+        fill = _sell_fill()
+        d = decompose(fill, fee_paid=0.11, funding_accrued=0.05)
+        assert abs(d.total_pnl - (d.signal_pnl + d.slippage_pnl + d.fee_pnl + d.funding_pnl)) < 1e-9
+        assert d.funding_pnl == pytest.approx(-0.05)
+
+
+# ---------------------------------------------------------------------------
+# decompose(): sell semantics
+# ---------------------------------------------------------------------------
+
+class TestDecomposeSell:
+    def test_sell_signal_pnl_is_mid_minus_entry_times_qty(self):
+        # signal_pnl = (mid_at_submit - entry_price) * qty
+        fill = _sell_fill(fill_price=110.0, entry_price=100.0, qty=1.0, mid=109.0)
+        d = decompose(fill, fee_paid=0.0)
+        assert d.signal_pnl == pytest.approx((109.0 - 100.0) * 1.0)
+
+    def test_sell_slippage_pnl_is_fill_minus_mid_times_qty(self):
+        # slippage_pnl = (fill_price - mid_at_submit) * qty
+        fill = _sell_fill(fill_price=110.0, entry_price=100.0, qty=1.0, mid=109.0)
+        d = decompose(fill, fee_paid=0.0)
+        assert d.slippage_pnl == pytest.approx((110.0 - 109.0) * 1.0)
+
+    def test_sell_total_equals_net_realized_pnl(self):
+        """For a sell: total_pnl should equal (fill - entry)*qty - fee."""
+        fill = _sell_fill(fill_price=110.0, entry_price=100.0, qty=2.0, mid=109.0)
+        fee = 0.22
+        d = decompose(fill, fee_paid=fee)
+        expected_net = (110.0 - 100.0) * 2.0 - fee
+        assert d.total_pnl == pytest.approx(expected_net)
+
+    def test_sell_fee_pnl_is_negative(self):
+        fill = _sell_fill()
+        d = decompose(fill, fee_paid=1.5)
+        assert d.fee_pnl == pytest.approx(-1.5)
+
+    def test_sell_slippage_negative_when_fill_below_mid(self):
+        # fill < mid for a sell → you got less than mid → negative slippage
+        fill = _sell_fill(fill_price=108.0, mid=109.0)
+        d = decompose(fill, fee_paid=0.0)
+        assert d.slippage_pnl < 0
+
+
+# ---------------------------------------------------------------------------
+# decompose(): buy semantics
+# ---------------------------------------------------------------------------
+
+class TestDecomposeBuy:
+    def test_buy_signal_pnl_is_zero(self):
+        fill = _buy_fill(fill_price=100.5, mid=100.0)
+        d = decompose(fill, fee_paid=0.10)
+        assert d.signal_pnl == 0.0
+
+    def test_buy_slippage_negative_when_fill_above_mid(self):
+        # fill > mid for a buy → you paid more than mid → negative slippage
+        fill = _buy_fill(fill_price=101.0, mid=100.0, qty=1.0)
+        d = decompose(fill, fee_paid=0.0)
+        assert d.slippage_pnl == pytest.approx(-(101.0 - 100.0) * 1.0)
+        assert d.slippage_pnl < 0
+
+    def test_buy_slippage_positive_when_fill_below_mid(self):
+        # fill < mid for a buy → you paid less than mid → positive slippage
+        fill = _buy_fill(fill_price=99.5, mid=100.0, qty=1.0)
+        d = decompose(fill, fee_paid=0.0)
+        assert d.slippage_pnl > 0
+
+
+# ---------------------------------------------------------------------------
+# CostDecomposer: accumulation and summaries
+# ---------------------------------------------------------------------------
+
+class TestCostDecomposer:
+    def test_add_and_cumulative(self):
+        cd = CostDecomposer()
+        fill1 = _sell_fill(ts=_ts(10))
+        fill2 = _buy_fill(ts=_ts(11))
+        d1 = cd.add_fill(fill1, fee_paid=0.11)
+        d2 = cd.add_fill(fill2, fee_paid=0.10)
+
+        summary = cd.cumulative_summary()
+        assert summary.num_fills == 2
+        assert summary.total_pnl == pytest.approx(d1.total_pnl + d2.total_pnl)
+        assert summary.total_fee_pnl == pytest.approx(-0.11 + -0.10)
+
+    def test_daily_summary_groups_by_date(self):
+        cd = CostDecomposer()
+        ts_today = datetime(2026, 4, 28, 12, 0, tzinfo=timezone.utc)
+        ts_yesterday = datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc)
+
+        cd.add_fill(_sell_fill(ts=ts_today), fee_paid=0.11)
+        cd.add_fill(_sell_fill(fill_id="f2", ts=ts_today), fee_paid=0.05)
+        cd.add_fill(_sell_fill(fill_id="f3", ts=ts_yesterday), fee_paid=0.08)
+
+        today_s = cd.daily_summary(date(2026, 4, 28))
+        yesterday_s = cd.daily_summary(date(2026, 4, 27))
+
+        assert today_s is not None
+        assert yesterday_s is not None
+        assert today_s.num_fills == 2
+        assert yesterday_s.num_fills == 1
+        assert today_s.total_fee_pnl == pytest.approx(-0.16)
+
+    def test_daily_summary_returns_none_for_empty_date(self):
+        cd = CostDecomposer()
+        result = cd.daily_summary(date(2099, 1, 1))
+        assert result is None
+
+    def test_all_daily_summaries_sorted(self):
+        cd = CostDecomposer()
+        for day in [28, 27, 26]:
+            ts = datetime(2026, 4, day, 12, 0, tzinfo=timezone.utc)
+            cd.add_fill(_sell_fill(fill_id=f"f_{day}", ts=ts), fee_paid=0.01)
+
+        summaries = cd.all_daily_summaries()
+        dates = [s.date for s in summaries]
+        assert dates == sorted(dates)
+        assert len(dates) == 3
+
+
+# ---------------------------------------------------------------------------
+# CostDecomposer.from_audit_log()
+# ---------------------------------------------------------------------------
+
+class TestFromAuditLog:
+    def _write_audit(self, tmp_path: Path, records: list) -> Path:
+        p = tmp_path / "audit.jsonl"
+        with open(p, "w") as f:
+            for r in records:
+                f.write(json.dumps(r) + "\n")
+        return p
+
+    def _fill_record(self, side: str, price: float, qty: float, fee: float,
+                     pnl: float = 0.0, entry_price: float = 0.0,
+                     mid_price: float = None) -> dict:
+        return {
+            "ts": "2026-04-28T12:00:00Z",
+            "type": "fill",
+            "payload": {
+                "fill_id": f"fill_{side}_{price}",
+                "side": side,
+                "price": price,
+                "mid_price": mid_price if mid_price is not None else price,
+                "quantity": qty,
+                "fee": fee,
+                "pnl": pnl,
+                "entry_price": entry_price,
+            },
+            "hash": "abc",
+        }
+
+    def test_loads_fill_records(self, tmp_path):
+        path = self._write_audit(tmp_path, [
+            self._fill_record("buy", 100.0, 1.0, 0.10),
+            self._fill_record("sell", 110.0, 1.0, 0.11, pnl=10.0, entry_price=100.0),
+        ])
+        cd = CostDecomposer.from_audit_log(path)
+        assert len(cd.fills()) == 2
+
+    def test_ignores_non_fill_records(self, tmp_path):
+        path = self._write_audit(tmp_path, [
+            {"ts": "2026-04-28T12:00:00Z", "type": "risk_event", "payload": {}, "hash": "x"},
+            self._fill_record("buy", 100.0, 1.0, 0.10),
+        ])
+        cd = CostDecomposer.from_audit_log(path)
+        assert len(cd.fills()) == 1
+
+    def test_returns_empty_for_missing_file(self, tmp_path):
+        cd = CostDecomposer.from_audit_log(tmp_path / "nonexistent.jsonl")
+        assert len(cd.fills()) == 0
+
+    def test_sell_total_pnl_from_audit_log(self, tmp_path):
+        path = self._write_audit(tmp_path, [
+            self._fill_record("sell", 110.0, 2.0, 0.22,
+                              pnl=20.0, entry_price=100.0, mid_price=109.0),
+        ])
+        cd = CostDecomposer.from_audit_log(path)
+        fills = cd.fills()
+        assert len(fills) == 1
+        d = fills[0]
+        # total_pnl == (fill - entry) * qty - fee = (110-100)*2 - 0.22 = 19.78
+        assert d.total_pnl == pytest.approx(19.78)
+
+
+# ---------------------------------------------------------------------------
+# A6.5 Regression: 4-axis sum == realized P&L (< $0.01)
+# ---------------------------------------------------------------------------
+
+class TestRegressionIdentity:
+    """4-axis sum must equal (fill_price - entry_price) * qty - fee for sells."""
+
+    @pytest.mark.parametrize("fill_price,entry_price,qty,fee,mid", [
+        (110.0, 100.0, 1.0, 0.11, 109.0),
+        (50000.0, 45000.0, 0.01, 5.0, 49900.0),
+        (1.05, 1.00, 1000.0, 0.50, 1.04),
+        (100.0, 100.0, 1.0, 0.10, 100.0),  # breakeven trade
+        (90.0, 100.0, 1.0, 0.09, 91.0),    # losing trade
+    ])
+    def test_sell_regression(self, fill_price, entry_price, qty, fee, mid):
+        fill = FillRecord(
+            fill_id="r",
+            timestamp=_ts(),
+            side="sell",
+            fill_price=fill_price,
+            qty=qty,
+            entry_price=entry_price,
+            mid_at_submit=mid,
+        )
+        d = decompose(fill, fee_paid=fee)
+        realized_net = (fill_price - entry_price) * qty - fee
+        assert verify_decomposition_identity(d, realized_net, tol=0.01), (
+            f"Identity failed: 4-axis={d.total_pnl:.6f}, realized={realized_net:.6f}"
+        )
+
+    def test_decomposer_cumulative_matches_sum_of_fills(self):
+        """CostDecomposer total must equal sum of individual decompose() calls."""
+        cd = CostDecomposer()
+        fills_data = [
+            (_sell_fill(fill_price=110.0, entry_price=100.0, qty=1.0, mid=109.5, fill_id="s1"), 0.11),
+            (_buy_fill(fill_price=100.5, qty=1.0, mid=100.0, fill_id="b1"), 0.10),
+            (_sell_fill(fill_price=120.0, entry_price=105.0, qty=0.5, mid=119.0, fill_id="s2"), 0.06),
+        ]
+        expected_total = 0.0
+        for fill, fee in fills_data:
+            d = decompose(fill, fee_paid=fee)
+            expected_total += d.total_pnl
+            cd.add(d)
+
+        summary = cd.cumulative_summary()
+        assert abs(summary.total_pnl - expected_total) < 1e-9


### PR DESCRIPTION
## Summary

- **`deployment/analysis/cost_decomposition.py`** — Core: `FillRecord`, `FillDecomposition`, `decompose()`, `CostDecomposer`, `from_audit_log()` factory, `verify_decomposition_identity()` regression helper
- **`scripts/generate_daily_cost_report.py`** — Reads `audit_log/audit.jsonl` → `docs/reports/cost_breakdown_{date}.md` (4-axis table, ASCII bar, A6.5 regression check)
- **`deployment/monitoring/dashboard.py`** — `GET /cost-breakdown` endpoint; `start_dashboard(..., cost_decomposer=None)` optional wiring, backward compatible
- **`deployment/paper_trader.py`** — `_execute_buy` / `_execute_sell`에서 `audit_logger.log_fill()` 호출 추가 (mid_price, entry_price 포함)
- **`deployment/launchd/com.tradingbot.daily-cost-report.plist`** — 00:30 UTC daily launchd schedule
- **`config/deployment.yaml`** — `cost_decomposition:` 섹션 (`enable_funding_tracking: false`)
- **`docs/phase8/cost_decomposition.md`** — 참조 문서

## 4-axis decomposition

```
total_pnl = signal_pnl + slippage_pnl + fee_pnl + funding_pnl

sell: signal_pnl   = (mid_at_submit − entry_price) × qty   ← 전략 알파
      slippage_pnl = (fill_price − mid_at_submit) × qty    ← 체결 품질
buy:  signal_pnl   = 0  (미실현)
      slippage_pnl = −(fill_price − mid_at_submit) × qty   ← 진입 비용
fee_pnl     = −fee_paid
funding_pnl = −funding_accrued  (spot → 0)
```

Algebraic identity is guaranteed: `total_pnl == sum(4 axes)` always.

## Tests

25 new tests (all pass): algebraic identity, sell/buy semantics, daily aggregation, audit log parsing, A6.5 regression (`|4-axis sum − realized P&L| < $0.01`).

Pre-existing `test_dollar_drill_simulation` timeout failure is unrelated and pre-dates this PR (confirmed by stash test).

## Test plan

- [ ] `pytest tests/deployment/analysis/test_cost_decomposition.py` — 25/25 pass
- [ ] `python scripts/generate_daily_cost_report.py --date 2026-04-28` — runs without error (empty report OK if no fills)
- [ ] `GET /cost-breakdown` responds `{"status": "disabled"}` when not wired
- [ ] Paper trader writes `"type":"fill"` records to audit.jsonl on buy/sell

🤖 Generated with [Claude Code](https://claude.com/claude-code)