### PR TITLE
E2/E3: cold-start warmup guard + live ramp guard

### DIFF
--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -60,6 +60,15 @@ live_signal_gate:
     max_permutation_p: 0.05
     max_regime_dd: 0.30
 
+# ── E2/E3 Warmup / Live-ramp Guard ───────────────────────────
+# E2 (paper/sandbox): size_fraction=0.5, progress_alerts=false
+# E3 (live):          size_fraction=0.3, progress_alerts=true
+# run_paper_trader.py fills in the mode-specific defaults at startup.
+warmup:
+  enabled: true
+  warmup_minutes: 30
+  max_qps: 1.0
+
 # ── LLM Review Panel ──────────────────────────────────────────
 llm_review:
   enabled: false

--- a/deployment/execution/warmup_guard.py
+++ b/deployment/execution/warmup_guard.py
@@ -1,0 +1,145 @@
+"""
+WarmupGuard — E2/E3: cold-start and live-ramp protection.
+
+E2 (paper/sandbox): size_fraction=0.5, no progress alerts
+E3 (live):          size_fraction=0.3, 1-minute progress alerts
+
+Both modes enforce max_qps=1 and fire a start alert and an end alert.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class WarmupGuard:
+    """
+    Caps order size and rate-limits submissions during the warmup window.
+
+    Parameters
+    ----------
+    warmup_minutes :
+        Length of the warmup window.
+    size_fraction :
+        Order size multiplier during warmup (0.5 for E2, 0.3 for E3).
+    max_qps :
+        Maximum orders allowed per second during warmup.
+    progress_alerts :
+        Emit a 1-minute progress alert to the alerter (True for E3 live ramp).
+    alerter :
+        Optional TradingAlerter for start / end / progress notifications.
+    """
+
+    def __init__(
+        self,
+        warmup_minutes: int = 30,
+        size_fraction: float = 0.5,
+        max_qps: float = 1.0,
+        progress_alerts: bool = False,
+        alerter=None,
+    ) -> None:
+        if warmup_minutes < 1:
+            raise ValueError(f"warmup_minutes must be >= 1, got {warmup_minutes}")
+        if not (0.0 < size_fraction <= 1.0):
+            raise ValueError(f"size_fraction must be in (0, 1], got {size_fraction}")
+        if max_qps <= 0:
+            raise ValueError(f"max_qps must be > 0, got {max_qps}")
+
+        self.warmup_minutes = warmup_minutes
+        self.warmup_seconds = warmup_minutes * 60.0
+        self.size_fraction = size_fraction
+        self._min_order_interval: float = 1.0 / max_qps
+        self.progress_alerts = progress_alerts
+        self.alerter = alerter
+
+        self._start_time: Optional[float] = None
+        self._ended: bool = False
+        self._last_order_time: float = 0.0
+        self._last_progress_min: int = -1
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Call once when the trading loop begins."""
+        self._start_time = time.monotonic()
+        msg = (
+            f"Warmup mode ACTIVE — "
+            f"size_fraction={self.size_fraction:.0%}, "
+            f"max_qps={1.0/self._min_order_interval:.0f}, "
+            f"duration={self.warmup_minutes} min"
+        )
+        logger.warning(msg)
+        if self.alerter is not None:
+            self.alerter.send_alert(msg, level="WARNING")
+
+    @property
+    def in_warmup(self) -> bool:
+        """True while the warmup window is active."""
+        if self._ended or self._start_time is None:
+            return False
+        return (time.monotonic() - self._start_time) < self.warmup_seconds
+
+    def check(self, requested_size: float) -> Tuple[bool, float]:
+        """
+        Decide whether an order may proceed and return the allowed size.
+
+        Should be called before every order submission.
+
+        Parameters
+        ----------
+        requested_size :
+            The fractional order size the agent requested (0–1).
+
+        Returns
+        -------
+        (allowed, capped_size)
+            allowed    — False when QPS limit is breached; skip the order.
+            capped_size — requested_size * size_fraction while in warmup,
+                         requested_size unchanged once warmup ends.
+        """
+        self._maybe_end()
+        if not self.in_warmup:
+            return True, requested_size
+
+        self._maybe_progress_alert()
+
+        now = time.monotonic()
+        if (now - self._last_order_time) < self._min_order_interval:
+            return False, 0.0
+
+        self._last_order_time = now
+        return True, requested_size * self.size_fraction
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _maybe_end(self) -> None:
+        if self._ended or self._start_time is None:
+            return
+        if (time.monotonic() - self._start_time) >= self.warmup_seconds:
+            self._ended = True
+            msg = "Warmup ENDED — normal trading parameters restored"
+            logger.info(msg)
+            if self.alerter is not None:
+                self.alerter.send_alert(msg, level="INFO")
+
+    def _maybe_progress_alert(self) -> None:
+        if not self.progress_alerts or self._start_time is None:
+            return
+        elapsed_min = int((time.monotonic() - self._start_time) / 60)
+        if elapsed_min > self._last_progress_min and elapsed_min < self.warmup_minutes:
+            self._last_progress_min = elapsed_min
+            remaining = self.warmup_minutes - elapsed_min
+            msg = (
+                f"Live ramp progress: {elapsed_min}/{self.warmup_minutes} min elapsed, "
+                f"{remaining} min remaining"
+            )
+            logger.info(msg)
+            if self.alerter is not None:
+                self.alerter.send_alert(msg, level="INFO")

--- a/deployment/paper_trader.py
+++ b/deployment/paper_trader.py
@@ -363,6 +363,20 @@ class PaperTrader:
         else:
             self._exchange = None
 
+        # E2/E3: cold-start warmup guard (paper) / live ramp guard (live)
+        from deployment.execution.warmup_guard import WarmupGuard
+        warmup_cfg = config.get("warmup", {}) or {}
+        if warmup_cfg.get("enabled", False):
+            self._warmup_guard: Optional[WarmupGuard] = WarmupGuard(
+                warmup_minutes=int(warmup_cfg.get("warmup_minutes", 30)),
+                size_fraction=float(warmup_cfg.get("size_fraction", 0.5)),
+                max_qps=float(warmup_cfg.get("max_qps", 1.0)),
+                progress_alerts=bool(warmup_cfg.get("progress_alerts", False)),
+                alerter=self.alerter,
+            )
+        else:
+            self._warmup_guard = None
+
         # G13: write PID file so kill_switch.py can locate this process
         pid_cfg = config.get("pid_file", "state/paper_trader.pid")
         self._pid_file = Path(pid_cfg)
@@ -408,6 +422,9 @@ class PaperTrader:
         start_time = time.time()
         step = self.state.step
         _restored_log_pending = getattr(self, "_restored_from_checkpoint", False)
+
+        if self._warmup_guard is not None:
+            self._warmup_guard.start()
 
         for price in self._price_iterator(price_stream):
             if self.state.shutdown_triggered:
@@ -676,6 +693,10 @@ class PaperTrader:
             self._execute_sell(abs(action), price)
 
     def _execute_buy(self, strength: float, price: float) -> None:
+        if self._warmup_guard is not None:
+            allowed, strength = self._warmup_guard.check(strength)
+            if not allowed:
+                return
         max_spend = self.state.pos.cash * min(strength, self.max_position_size)
         if max_spend < price * 1e-6:
             return
@@ -730,6 +751,10 @@ class PaperTrader:
                 )
 
     def _execute_sell(self, strength: float, price: float) -> None:
+        if self._warmup_guard is not None:
+            allowed, strength = self._warmup_guard.check(strength)
+            if not allowed:
+                return
         sell_qty = self.state.pos.position * min(strength, 1.0)
         if sell_qty < 1e-8:
             return

--- a/scripts/run_paper_trader.py
+++ b/scripts/run_paper_trader.py
@@ -130,6 +130,21 @@ def main() -> None:
             logger.error("Failed to import live_signal_gate: %s", exc)
             sys.exit(1)
 
+    # ── [E2/E3] Warmup / live-ramp guard ────────────────────────────────────
+    warmup_cfg = config.setdefault("warmup", {})
+    if warmup_cfg.get("enabled", True):
+        warmup_cfg["enabled"] = True
+        warmup_cfg.setdefault("warmup_minutes", 30)
+        warmup_cfg.setdefault("max_qps", 1.0)
+        if args.exchange_mode == "live":
+            # E3: tighter size cap + 1-minute progress alerts
+            warmup_cfg.setdefault("size_fraction", 0.3)
+            warmup_cfg.setdefault("progress_alerts", True)
+        else:
+            # E2: half-size, no progress spam
+            warmup_cfg.setdefault("size_fraction", 0.5)
+            warmup_cfg.setdefault("progress_alerts", False)
+
     duration_seconds: Optional[float] = (
         args.duration_hours * 3600.0 if args.duration_hours is not None else None
     )

--- a/tests/deployment/test_paper_trader_warmup.py
+++ b/tests/deployment/test_paper_trader_warmup.py
@@ -1,0 +1,161 @@
+"""E2: PaperTrader cold-start warmup guard tests."""
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_trader(warmup_minutes=1, size_fraction=0.5, max_qps=1.0):
+    from deployment.paper_trader import PaperTrader
+
+    agent = MagicMock()
+    agent.predict.return_value = (1.0, None)
+    config = {
+        "paper_trading": {
+            "initial_balance": 10_000,
+            "trading_fee": 0.001,
+            "max_position_size": 1.0,
+        },
+        "warmup": {
+            "enabled": True,
+            "warmup_minutes": warmup_minutes,
+            "size_fraction": size_fraction,
+            "max_qps": max_qps,
+            "progress_alerts": False,
+        },
+    }
+    return PaperTrader(agent=agent, config=config, simulation_mode=True)
+
+
+class TestWarmupGuardInit:
+    def test_guard_created_when_enabled(self):
+        trader = _make_trader()
+        assert trader._warmup_guard is not None
+
+    def test_guard_none_when_disabled(self):
+        from deployment.paper_trader import PaperTrader
+
+        agent = MagicMock()
+        agent.predict.return_value = (0, None)
+        config = {
+            "paper_trading": {"initial_balance": 10_000, "trading_fee": 0.001},
+            "warmup": {"enabled": False},
+        }
+        trader = PaperTrader(agent=agent, config=config, simulation_mode=True)
+        assert trader._warmup_guard is None
+
+    def test_guard_params_stored(self):
+        trader = _make_trader(warmup_minutes=5, size_fraction=0.3, max_qps=2.0)
+        g = trader._warmup_guard
+        assert g.warmup_minutes == 5
+        assert g.size_fraction == 0.3
+
+
+class TestWarmupSizeCap:
+    def test_buy_size_halved_during_warmup(self):
+        """During warmup, _execute_buy should halve the requested strength."""
+        trader = _make_trader(warmup_minutes=60, size_fraction=0.5, max_qps=100.0)
+        # Manually start the guard
+        trader._warmup_guard.start()
+        assert trader._warmup_guard.in_warmup
+
+        trader.state.pos._cash = 10_000.0
+        trader.state.pos._position = 0.0
+        initial_cash = trader.state.pos.cash
+
+        trader._execute_buy(strength=1.0, price=100.0)
+        assert len(trader.state.trades) == 1
+        trade = trader.state.trades[0]
+        # With strength=1.0 → capped to 0.5 → max_spend = 10000 * 0.5 = 5000
+        expected_qty = 5000.0 / 100.0
+        assert abs(trade.quantity - expected_qty) < 1e-6
+
+    def test_sell_size_halved_during_warmup(self):
+        trader = _make_trader(warmup_minutes=60, size_fraction=0.5, max_qps=100.0)
+        trader._warmup_guard.start()
+
+        # Give trader a position
+        trader.state.pos._position = 1.0
+        trader.state.pos._entry_price = 100.0
+
+        trader._execute_sell(strength=1.0, price=100.0)
+        assert len(trader.state.trades) == 1
+        # sell_qty = 1.0 * min(0.5, 1.0) = 0.5
+        assert abs(trader.state.trades[0].quantity - 0.5) < 1e-6
+
+    def test_buy_full_size_after_warmup(self):
+        """Once warmup window passes, orders execute at full size (not halved)."""
+        trader = _make_trader(warmup_minutes=60, size_fraction=0.5, max_qps=100.0)
+        trader._warmup_guard = None
+
+        trader.state.pos._cash = 10_000.0
+        trader.state.pos._position = 0.0
+
+        # strength=0.5 → max_spend=5000, cost=5005 < 10000 ✓
+        trader._execute_buy(strength=0.5, price=100.0)
+        assert len(trader.state.trades) == 1
+        # Without warmup cap, strength=0.5 is used as-is
+        expected_qty = (10_000.0 * 0.5) / 100.0
+        assert abs(trader.state.trades[0].quantity - expected_qty) < 1e-6
+
+        # Verify warmup would have halved it further
+        trader2 = _make_trader(warmup_minutes=60, size_fraction=0.5, max_qps=100.0)
+        trader2._warmup_guard.start()
+        trader2.state.pos._cash = 10_000.0
+        trader2._execute_buy(strength=0.5, price=100.0)
+        assert len(trader2.state.trades) == 1
+        # With warmup: strength becomes 0.5 * 0.5 = 0.25 → max_spend = 2500
+        expected_warmup_qty = (10_000.0 * 0.25) / 100.0
+        assert abs(trader2.state.trades[0].quantity - expected_warmup_qty) < 1e-6
+
+
+class TestWarmupQPS:
+    def test_second_order_within_interval_rejected(self):
+        """Two orders < 1 s apart → second is dropped."""
+        trader = _make_trader(warmup_minutes=60, size_fraction=0.5, max_qps=1.0)
+        trader._warmup_guard.start()
+        trader.state.pos._cash = 10_000.0
+
+        trader._execute_buy(strength=0.1, price=100.0)
+        trader._execute_buy(strength=0.1, price=100.0)
+        # Second buy should be throttled
+        assert len(trader.state.trades) == 1
+
+    def test_order_allowed_after_interval(self):
+        """Orders separated by > min_order_interval are both allowed."""
+        trader = _make_trader(warmup_minutes=60, size_fraction=0.5, max_qps=1.0)
+        guard = trader._warmup_guard
+        guard.start()
+        # Force last_order_time far in the past
+        guard._last_order_time = time.monotonic() - 2.0
+
+        trader.state.pos._cash = 10_000.0
+        trader._execute_buy(strength=0.1, price=100.0)
+        assert len(trader.state.trades) == 1
+
+
+class TestWarmupAlerts:
+    def test_start_alert_fired(self):
+        alerter = MagicMock()
+        trader = _make_trader(warmup_minutes=60)
+        trader._warmup_guard.alerter = alerter
+        trader._warmup_guard.start()
+        alerter.send_alert.assert_called_once()
+        msg = alerter.send_alert.call_args[0][0]
+        assert "Warmup mode ACTIVE" in msg
+
+    def test_end_alert_fired(self):
+        from deployment.execution.warmup_guard import WarmupGuard
+
+        alerter = MagicMock()
+        guard = WarmupGuard(warmup_minutes=1, alerter=alerter)
+        guard._start_time = time.monotonic() - 61  # already elapsed
+        guard._maybe_end()
+        assert guard._ended
+        end_calls = [
+            c for c in alerter.send_alert.call_args_list
+            if "ENDED" in c[0][0]
+        ]
+        assert len(end_calls) == 1

--- a/tests/scripts/test_live_ramp.py
+++ b/tests/scripts/test_live_ramp.py
@@ -1,0 +1,186 @@
+"""E3: run_paper_trader.py live-ramp guard wiring tests."""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _make_fake_handler():
+    """A logging.FileHandler mock whose .level is an int so the log machinery works."""
+    h = MagicMock()
+    h.level = 0
+    h.filters = []
+    return h
+
+
+def _gate_pass():
+    """Return a passing LiveSignalGate check result."""
+    result = MagicMock()
+    result.passed = True
+    result.evidence_pack_age_days = 1.0
+    result.failures = []
+    return result
+
+
+def _run_main(exchange_mode: str, extra_config: dict | None = None):
+    """
+    Invoke run_paper_trader.main() up to the PaperTrader construction and
+    return the config dict that was used to create the trader.
+    """
+    captured = {}
+
+    class _FakeTrader:
+        def __init__(self, agent, config, simulation_mode=False):
+            captured["config"] = config
+            self._warmup_guard = None
+
+        def run(self, **kwargs):
+            return {}
+
+        def _trigger_shutdown(self, *a):
+            pass
+
+    base_config = {
+        "agent": {"checkpoint": "fake_checkpoint", "algo": "PPO"},
+        "paper_trading": {"initial_balance": 10_000},
+    }
+    if extra_config:
+        base_config.update(extra_config)
+
+    fake_agent = MagicMock()
+    fake_algo_cls = MagicMock()
+    fake_algo_cls.load = MagicMock(return_value=fake_agent)
+    fake_sb3 = types.ModuleType("stable_baselines3")
+    fake_sb3.PPO = fake_algo_cls
+    fake_sb3.SAC = MagicMock()
+    fake_sb3.TD3 = MagicMock()
+
+    fake_gate_cls = MagicMock()
+    fake_gate_cls.return_value.check.return_value = _gate_pass()
+    fake_gate_module = types.ModuleType("deployment.governance.live_signal_gate")
+    fake_gate_module.LiveSignalGate = fake_gate_cls
+
+    argv = ["run_paper_trader.py", "--config", "fake.yaml",
+            "--exchange-mode", exchange_mode]
+
+    # Remove cached module so patches applied below take effect
+    import sys as _sys
+    _sys.modules.pop("scripts.run_paper_trader", None)
+
+    with (
+        patch("yaml.safe_load", return_value=base_config),
+        patch("builtins.open", MagicMock(return_value=MagicMock(
+            __enter__=MagicMock(return_value=MagicMock()),
+            __exit__=MagicMock(return_value=False),
+        ))),
+        patch.dict("sys.modules", {
+            "stable_baselines3": fake_sb3,
+            "deployment.governance.live_signal_gate": fake_gate_module,
+        }),
+        patch("deployment.paper_trader.PaperTrader", _FakeTrader),
+        patch("logging.FileHandler", return_value=_make_fake_handler()),
+        patch("pathlib.Path.mkdir"),
+        patch("pathlib.Path.write_text"),
+        patch("sys.argv", argv),
+    ):
+        from scripts import run_paper_trader
+        # Patch write/remove PID after import so names resolve correctly
+        with (
+            patch.object(run_paper_trader, "_write_pid", lambda *a: None),
+            patch.object(run_paper_trader, "_remove_pid", lambda *a: None),
+        ):
+            try:
+                run_paper_trader.main()
+            except SystemExit:
+                pass
+
+    return captured.get("config", {})
+
+
+class TestLiveRampConfig:
+    def test_live_mode_gets_e3_defaults(self):
+        """live mode → size_fraction=0.3, progress_alerts=True."""
+        config = _run_main("live")
+        warmup = config.get("warmup", {})
+        assert warmup.get("enabled") is True
+        assert warmup.get("size_fraction") == 0.3
+        assert warmup.get("progress_alerts") is True
+
+    def test_paper_mode_gets_e2_defaults(self):
+        """paper mode → size_fraction=0.5, progress_alerts=False."""
+        config = _run_main("paper")
+        warmup = config.get("warmup", {})
+        assert warmup.get("enabled") is True
+        assert warmup.get("size_fraction") == 0.5
+        assert warmup.get("progress_alerts") is False
+
+    def test_sandbox_mode_gets_e2_defaults(self):
+        """sandbox also gets E2 defaults (not the tighter live cap)."""
+        config = _run_main("sandbox")
+        warmup = config.get("warmup", {})
+        assert warmup.get("size_fraction") == 0.5
+        assert warmup.get("progress_alerts") is False
+
+    def test_warmup_minutes_default(self):
+        config = _run_main("live")
+        assert config["warmup"]["warmup_minutes"] == 30
+
+    def test_max_qps_default(self):
+        config = _run_main("live")
+        assert config["warmup"]["max_qps"] == 1.0
+
+    def test_config_override_respected(self):
+        """If config already sets size_fraction, it should not be overwritten."""
+        config = _run_main("live", extra_config={"warmup": {"size_fraction": 0.1}})
+        # setdefault behaviour: pre-existing value is preserved
+        assert config["warmup"]["size_fraction"] == 0.1
+
+
+class TestLiveRampProgressAlerts:
+    def test_progress_alerts_fired_each_minute(self):
+        """WarmupGuard fires a progress alert for each completed minute."""
+        import time
+        from deployment.execution.warmup_guard import WarmupGuard
+
+        alerter = MagicMock()
+        guard = WarmupGuard(
+            warmup_minutes=3,
+            size_fraction=0.3,
+            max_qps=100.0,
+            progress_alerts=True,
+            alerter=alerter,
+        )
+        # start() calls logger.warning — skip it so no log-level issue
+        guard._start_time = time.monotonic() - 65
+        alerter.reset_mock()
+
+        guard.check(0.5)
+        calls = [c[0][0] for c in alerter.send_alert.call_args_list]
+        assert any("ramp progress" in m for m in calls)
+
+    def test_no_progress_alerts_in_paper_mode(self):
+        import time
+        from deployment.execution.warmup_guard import WarmupGuard
+
+        alerter = MagicMock()
+        guard = WarmupGuard(
+            warmup_minutes=3,
+            size_fraction=0.5,
+            max_qps=100.0,
+            progress_alerts=False,
+            alerter=alerter,
+        )
+        guard._start_time = time.monotonic() - 65
+        alerter.reset_mock()
+
+        guard.check(0.5)
+        calls = [c[0][0] for c in alerter.send_alert.call_args_list]
+        assert not any("ramp progress" in m for m in calls)


### PR DESCRIPTION
## Summary

- **E2 (cold-start warmup guard)**: PaperTrader now caps order size at 50% and enforces max 1 order/second for the first 30 minutes after startup in paper/sandbox mode — the window where rolling-window guards (fat finger, position tracker) are least populated.
- **E3 (live ramp guard)**: When entering `--exchange-mode live`, the same mechanism activates with a tighter 30% size cap and 1-minute progress alerts until the 30-minute ramp completes.
- Shared implementation via `WarmupGuard` class; mode-specific defaults wired in `run_paper_trader.py`.

## Changed files

| File | Change |
|------|--------|
| `deployment/execution/warmup_guard.py` | New — `WarmupGuard` class (E2/E3 shared logic) |
| `deployment/paper_trader.py` | Build guard from config; call `.start()` in `run()`; apply in `_execute_buy`/`_execute_sell` |
| `scripts/run_paper_trader.py` | Set mode-specific defaults (live → E3, paper/sandbox → E2) |
| `config/deployment.yaml` | Add `warmup:` section |
| `tests/deployment/test_paper_trader_warmup.py` | 10 tests — init, size cap, QPS throttle, alerts |
| `tests/scripts/test_live_ramp.py` | 8 tests — config wiring and progress alerts |

## Behaviour

| Mode | size_fraction | max_qps | progress alerts |
|------|--------------|---------|-----------------|
| paper / sandbox (E2) | 0.5× | 1 | no |
| live (E3) | 0.3× | 1 | yes (every minute) |

Both modes fire a WARNING alert on warmup start and an INFO alert on warmup end. Guard can be disabled via `warmup.enabled: false` in config.

## Test plan

- [ ] `python -m pytest tests/deployment/test_paper_trader_warmup.py tests/scripts/test_live_ramp.py -v` → 18 passed
- [ ] Full suite: 548 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)