### PR TITLE
E5: audit chain time-travel replay

### DIFF
--- a/scripts/audit_replay.py
+++ b/scripts/audit_replay.py
@@ -1,0 +1,273 @@
+"""
+Time-travel replay of an audit log for post-incident root-cause analysis.
+
+Walks the .jsonl audit log, applies every ``fill`` record to a fresh
+PositionTracker, and optionally compares the final state against an
+expected snapshot.  Useful after an incident: given the log, reproduce
+exactly what happened to the position and spot where it diverged.
+
+Usage
+-----
+    python scripts/audit_replay.py <audit.jsonl>
+    python scripts/audit_replay.py <audit.jsonl> --from-ts 2026-05-01T10:00:00
+    python scripts/audit_replay.py <audit.jsonl> --from-hash abc123def
+    python scripts/audit_replay.py <audit.jsonl> --from-line 42
+    python scripts/audit_replay.py <audit.jsonl> --expected snapshot.json
+    python scripts/audit_replay.py <audit.jsonl> --initial-cash 50000 --no-verify
+
+Exit codes
+----------
+    0  replay complete, no drift
+    1  drift detected, hash-chain break, or unreadable file
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# Allow running from the repo root without installing as a package.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from deployment.execution.position_tracker import PositionTracker
+
+_GENESIS_HASH = "0" * 64
+
+
+# ---------------------------------------------------------------------------
+# Hash-chain helpers (mirrors verify_audit_log.py logic)
+# ---------------------------------------------------------------------------
+
+def _sha256(prev_hash: str, payload: Dict[str, Any]) -> str:
+    raw = prev_hash + json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _load_records(log_path: str) -> Tuple[List[Dict[str, Any]], bool]:
+    """Load all records.  Returns (records, ok) where ok=False on parse error."""
+    records: List[Dict[str, Any]] = []
+    try:
+        with open(log_path, encoding="utf-8") as fh:
+            for lineno, line in enumerate(fh, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError as exc:
+                    print(f"ERROR: line {lineno}: {exc}", file=sys.stderr)
+                    return records, False
+    except OSError as exc:
+        print(f"ERROR: cannot open {log_path}: {exc}", file=sys.stderr)
+        return [], False
+    return records, True
+
+
+def _verify_chain(records: List[Dict[str, Any]]) -> bool:
+    """Verify hash chain integrity. Returns True if intact."""
+    prev = _GENESIS_HASH
+    for i, rec in enumerate(records, start=1):
+        if "payload" not in rec or "hash" not in rec:
+            print(f"ERROR: record {i}: missing payload or hash", file=sys.stderr)
+            return False
+        expected = _sha256(prev, rec["payload"])
+        if rec["hash"] != expected:
+            print(
+                f"ERROR: record {i} hash mismatch\n"
+                f"  type    : {rec.get('type', '?')}\n"
+                f"  ts      : {rec.get('ts', '?')}\n"
+                f"  stored  : {rec['hash']}\n"
+                f"  expected: {expected}",
+                file=sys.stderr,
+            )
+            return False
+        prev = rec["hash"]
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Start-point selection
+# ---------------------------------------------------------------------------
+
+def _find_start(
+    records: List[Dict[str, Any]],
+    from_line: Optional[int],
+    from_ts: Optional[str],
+    from_hash: Optional[str],
+) -> int:
+    """Return the index into records where replay should begin (0-based)."""
+    if from_line is not None:
+        idx = from_line - 1  # user-facing lines are 1-based
+        if idx < 0 or idx >= len(records):
+            print(
+                f"ERROR: --from-line {from_line} is out of range "
+                f"(log has {len(records)} records)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return idx
+    if from_hash is not None:
+        for i, rec in enumerate(records):
+            if rec.get("hash", "").startswith(from_hash):
+                return i
+        print(f"ERROR: --from-hash prefix '{from_hash}' not found", file=sys.stderr)
+        sys.exit(1)
+    if from_ts is not None:
+        for i, rec in enumerate(records):
+            if rec.get("ts", "") >= from_ts:
+                return i
+        print(f"ERROR: --from-ts '{from_ts}' is after the last record", file=sys.stderr)
+        sys.exit(1)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Replay engine
+# ---------------------------------------------------------------------------
+
+def _apply_fill(tracker: PositionTracker, payload: Dict[str, Any]) -> None:
+    side = payload.get("side", "")
+    qty = float(payload.get("qty", 0.0))
+    price = float(payload.get("price", 0.0))
+    fee = float(payload.get("fee", 0.0))
+    if qty <= 0 or price <= 0:
+        return
+    tracker.update_price(price)
+    if side == "buy":
+        tracker.apply_buy(quantity=qty, price=price, fee=fee)
+    elif side == "sell":
+        tracker.apply_sell(quantity=qty, price=price, fee=fee)
+
+
+def replay(
+    records: List[Dict[str, Any]],
+    start_idx: int,
+    initial_cash: float,
+) -> Dict[str, Any]:
+    """Replay fill events from start_idx onward. Returns final tracker snapshot."""
+    tracker = PositionTracker(initial_cash=initial_cash)
+    fills_applied = 0
+    for rec in records[start_idx:]:
+        if rec.get("type") == "fill":
+            _apply_fill(tracker, rec.get("payload", {}))
+            fills_applied += 1
+    print(
+        f"Replayed {fills_applied} fill(s) from record "
+        f"{start_idx + 1}/{len(records)}.",
+        file=sys.stderr,
+    )
+    return tracker.snapshot()
+
+
+# ---------------------------------------------------------------------------
+# Drift detection
+# ---------------------------------------------------------------------------
+
+_DRIFT_TOLERANCE = 1e-8
+
+
+def _check_drift(
+    actual: Dict[str, Any], expected: Dict[str, Any]
+) -> bool:
+    """Return True if there is a detectable drift between the two snapshots."""
+    drifted = False
+    keys = sorted(set(actual) | set(expected))
+    for k in keys:
+        a = actual.get(k)
+        e = expected.get(k)
+        if a is None or e is None:
+            print(f"DRIFT  {k}: {e!r} → {a!r}", file=sys.stdout)
+            drifted = True
+            continue
+        try:
+            if abs(float(a) - float(e)) > _DRIFT_TOLERANCE:
+                print(f"DRIFT  {k}: expected={e}  actual={a}  delta={float(a)-float(e):+.10f}")
+                drifted = True
+        except (TypeError, ValueError):
+            if a != e:
+                print(f"DRIFT  {k}: {e!r} → {a!r}")
+                drifted = True
+    return drifted
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Replay an audit log and detect position state drift.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("log_path", help="Path to the .jsonl audit log")
+    p.add_argument(
+        "--from-line", type=int, metavar="N",
+        help="Start replay from line N (1-based)",
+    )
+    p.add_argument(
+        "--from-ts", metavar="ISO_TS",
+        help="Start replay from the first record at or after this timestamp",
+    )
+    p.add_argument(
+        "--from-hash", metavar="HEX_PREFIX",
+        help="Start replay from the record whose hash starts with this prefix",
+    )
+    p.add_argument(
+        "--initial-cash", type=float, default=10_000.0, metavar="FLOAT",
+        help="Starting cash for the replay PositionTracker (default: 10000)",
+    )
+    p.add_argument(
+        "--expected", metavar="JSON_FILE",
+        help="JSON file containing expected tracker snapshot; "
+             "exits 1 if drift is detected",
+    )
+    p.add_argument(
+        "--no-verify", action="store_true",
+        help="Skip hash-chain integrity check (faster on large logs)",
+    )
+    return p
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+
+    records, ok = _load_records(args.log_path)
+    if not ok:
+        sys.exit(1)
+    if not records:
+        print("WARNING: log is empty — nothing to replay.", file=sys.stderr)
+        print(json.dumps({}))
+        sys.exit(0)
+
+    if not args.no_verify:
+        if not _verify_chain(records):
+            sys.exit(1)
+        print(f"Chain OK ({len(records)} records).", file=sys.stderr)
+
+    start_idx = _find_start(records, args.from_line, args.from_ts, args.from_hash)
+    final_state = replay(records, start_idx, args.initial_cash)
+
+    if args.expected:
+        try:
+            with open(args.expected, encoding="utf-8") as fh:
+                expected = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"ERROR: cannot read --expected file: {exc}", file=sys.stderr)
+            sys.exit(1)
+        drifted = _check_drift(final_state, expected)
+        if drifted:
+            print("\nFinal replayed state:", file=sys.stderr)
+            print(json.dumps(final_state, indent=2), file=sys.stderr)
+            sys.exit(1)
+        else:
+            print("OK: no drift detected.", file=sys.stdout)
+    else:
+        print(json.dumps(final_state, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_audit_replay.py
+++ b/tests/scripts/test_audit_replay.py
@@ -1,0 +1,318 @@
+"""
+Tests for scripts/audit_replay.py.
+
+Two main properties:
+  1. Identity — replaying the same log produces the same final state.
+  2. Drift detection — a modified fill is flagged as a mismatch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+# Ensure repo root is importable so audit_replay can be imported directly.
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.audit_replay import (
+    _apply_fill,
+    _check_drift,
+    _find_start,
+    _load_records,
+    _verify_chain,
+    replay,
+)
+from deployment.execution.position_tracker import PositionTracker
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building synthetic audit logs
+# ---------------------------------------------------------------------------
+
+_GENESIS = "0" * 64
+
+
+def _sha256(prev: str, payload: Dict[str, Any]) -> str:
+    raw = prev + json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _make_record(
+    prev_hash: str,
+    record_type: str,
+    payload: Dict[str, Any],
+    ts: str = "2026-05-04T10:00:00+00:00",
+) -> Dict[str, Any]:
+    h = _sha256(prev_hash, payload)
+    return {"ts": ts, "type": record_type, "payload": payload, "hash": h}
+
+
+def _build_log(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Turn a list of (type, payload, ts?) tuples into a valid chained log."""
+    records = []
+    prev = _GENESIS
+    for ev in events:
+        rec = _make_record(prev, ev["type"], ev["payload"], ev.get("ts", "2026-05-04T10:00:00+00:00"))
+        records.append(rec)
+        prev = rec["hash"]
+    return records
+
+
+def _write_log(tmp_path: Path, records: List[Dict[str, Any]]) -> Path:
+    p = tmp_path / "audit.jsonl"
+    with open(p, "w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+BUY1 = {"type": "fill", "payload": {"side": "buy",  "qty": 0.1, "price": 50000.0, "fee": 5.0}}
+SELL1 = {"type": "fill", "payload": {"side": "sell", "qty": 0.05, "price": 52000.0, "fee": 2.6}}
+BUY2 = {"type": "fill", "payload": {"side": "buy",  "qty": 0.05, "price": 51000.0, "fee": 2.55}}
+MODEL = {"type": "model_decision", "payload": {"action": 1, "obs_hash": "abc"}}
+RISK  = {"type": "risk_event", "payload": {"type": "drawdown_breach", "value": 0.12}}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: chain verification
+# ---------------------------------------------------------------------------
+
+def test_verify_chain_ok(tmp_path):
+    records = _build_log([BUY1, SELL1, BUY2])
+    assert _verify_chain(records) is True
+
+
+def test_verify_chain_tampered_payload(tmp_path):
+    records = _build_log([BUY1, SELL1])
+    # Tamper with the second record's payload without updating its hash.
+    records[1] = dict(records[1])
+    records[1]["payload"] = dict(records[1]["payload"], qty=999.0)
+    assert _verify_chain(records) is False
+
+
+def test_verify_chain_empty():
+    assert _verify_chain([]) is True
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: fill application
+# ---------------------------------------------------------------------------
+
+def test_apply_fill_buy():
+    tracker = PositionTracker(initial_cash=10_000.0)
+    _apply_fill(tracker, {"side": "buy", "qty": 0.1, "price": 50_000.0, "fee": 5.0})
+    assert abs(tracker.position - 0.1) < 1e-9
+    assert abs(tracker.cash - (10_000.0 - 0.1 * 50_000.0 - 5.0)) < 1e-6
+
+
+def test_apply_fill_sell():
+    tracker = PositionTracker(initial_cash=10_000.0)
+    _apply_fill(tracker, {"side": "buy",  "qty": 0.1, "price": 50_000.0, "fee": 5.0})
+    _apply_fill(tracker, {"side": "sell", "qty": 0.05, "price": 52_000.0, "fee": 2.6})
+    assert abs(tracker.position - 0.05) < 1e-9
+
+
+def test_apply_fill_zero_qty_ignored():
+    tracker = PositionTracker(initial_cash=1_000.0)
+    _apply_fill(tracker, {"side": "buy", "qty": 0.0, "price": 50_000.0, "fee": 0.0})
+    assert tracker.position == 0.0
+    assert tracker.cash == 1_000.0
+
+
+# ---------------------------------------------------------------------------
+# Integration: replay produces deterministic output
+# ---------------------------------------------------------------------------
+
+def test_replay_identity(tmp_path):
+    """Replaying the same log twice gives the same snapshot."""
+    records = _build_log([BUY1, SELL1, BUY2])
+    state1 = replay(records, 0, initial_cash=10_000.0)
+    state2 = replay(records, 0, initial_cash=10_000.0)
+    assert state1 == state2
+
+
+def test_replay_ignores_non_fill_records(tmp_path):
+    """model_decision and risk_event records must not affect position state."""
+    records_with_noise = _build_log([BUY1, MODEL, RISK, SELL1])
+    records_clean = _build_log([BUY1, SELL1])
+    state_noise = replay(records_with_noise, 0, initial_cash=10_000.0)
+    state_clean = replay(records_clean, 0, initial_cash=10_000.0)
+    assert state_noise == state_clean
+
+
+def test_replay_from_line(tmp_path):
+    """--from-line should skip fills before the start point."""
+    records = _build_log([BUY1, SELL1, BUY2])
+    # Replay from line 2 — skip BUY1, replay SELL1 + BUY2
+    partial = replay(records, start_idx=1, initial_cash=10_000.0)
+    # Manual calculation: no buy before sell, so sell is a no-op (qty=0 clamped)
+    full = replay(records, start_idx=0, initial_cash=10_000.0)
+    assert partial != full  # position histories differ
+
+
+def test_replay_empty_log():
+    state = replay([], start_idx=0, initial_cash=5_000.0)
+    # No fills → initial cash, zero position, zero prices
+    assert state["position"] == 0.0
+    assert state["cash"] == 5_000.0
+
+
+# ---------------------------------------------------------------------------
+# Drift detection
+# ---------------------------------------------------------------------------
+
+def test_no_drift_identical():
+    a = {"cash": 100.0, "position": 0.5, "entry_price": 200.0,
+         "current_price": 210.0, "peak_value": 105.0}
+    assert _check_drift(a, a) is False
+
+
+def test_drift_detected_numeric():
+    actual   = {"cash": 100.0, "position": 0.5}
+    expected = {"cash": 99.0,  "position": 0.5}
+    assert _check_drift(actual, expected) is True
+
+
+def test_drift_within_tolerance():
+    actual   = {"cash": 100.000000001, "position": 0.5}
+    expected = {"cash": 100.0,         "position": 0.5}
+    # delta ~1e-9 < 1e-8 tolerance
+    assert _check_drift(actual, expected) is False
+
+
+def test_drift_missing_key():
+    actual   = {"cash": 100.0}
+    expected = {"cash": 100.0, "position": 0.0}
+    assert _check_drift(actual, expected) is True
+
+
+# ---------------------------------------------------------------------------
+# Start-point selection
+# ---------------------------------------------------------------------------
+
+def test_find_start_default():
+    records = _build_log([BUY1, SELL1])
+    assert _find_start(records, None, None, None) == 0
+
+
+def test_find_start_by_line():
+    records = _build_log([BUY1, SELL1, BUY2])
+    assert _find_start(records, from_line=2, from_ts=None, from_hash=None) == 1
+
+
+def test_find_start_by_hash():
+    records = _build_log([BUY1, SELL1])
+    prefix = records[1]["hash"][:8]
+    assert _find_start(records, None, None, from_hash=prefix) == 1
+
+
+def test_find_start_by_ts():
+    events = [
+        {**BUY1,  "ts": "2026-05-04T09:00:00+00:00"},
+        {**SELL1, "ts": "2026-05-04T11:00:00+00:00"},
+        {**BUY2,  "ts": "2026-05-04T12:00:00+00:00"},
+    ]
+    records = _build_log(events)
+    assert _find_start(records, None, from_ts="2026-05-04T10:00:00", from_hash=None) == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end tests (subprocess)
+# ---------------------------------------------------------------------------
+
+_SCRIPT = str(REPO_ROOT / "scripts" / "audit_replay.py")
+
+
+def test_cli_basic_output(tmp_path):
+    records = _build_log([BUY1, SELL1])
+    log_path = _write_log(tmp_path, records)
+    result = subprocess.run(
+        [sys.executable, _SCRIPT, str(log_path)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    state = json.loads(result.stdout)
+    assert "cash" in state
+    assert "position" in state
+
+
+def test_cli_expected_match(tmp_path):
+    records = _build_log([BUY1])
+    log_path = _write_log(tmp_path, records)
+    # First run to capture expected state
+    r1 = subprocess.run(
+        [sys.executable, _SCRIPT, str(log_path)],
+        capture_output=True, text=True,
+    )
+    expected_path = tmp_path / "expected.json"
+    expected_path.write_text(r1.stdout, encoding="utf-8")
+    # Second run with --expected should report no drift
+    r2 = subprocess.run(
+        [sys.executable, _SCRIPT, str(log_path), "--expected", str(expected_path)],
+        capture_output=True, text=True,
+    )
+    assert r2.returncode == 0
+    assert "no drift" in r2.stdout.lower()
+
+
+def test_cli_expected_drift(tmp_path):
+    records = _build_log([BUY1])
+    log_path = _write_log(tmp_path, records)
+    # Expected state with wrong cash
+    expected = {"cash": 0.0, "position": 0.0, "entry_price": 0.0,
+                "current_price": 0.0, "peak_value": 0.0}
+    expected_path = tmp_path / "expected.json"
+    expected_path.write_text(json.dumps(expected), encoding="utf-8")
+    r = subprocess.run(
+        [sys.executable, _SCRIPT, str(log_path), "--expected", str(expected_path)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 1
+    assert "DRIFT" in r.stdout
+
+
+def test_cli_broken_chain_exits_1(tmp_path):
+    records = _build_log([BUY1, SELL1])
+    # Tamper second record
+    records[1] = dict(records[1], payload=dict(records[1]["payload"], qty=999.0))
+    log_path = _write_log(tmp_path, records)
+    r = subprocess.run(
+        [sys.executable, _SCRIPT, str(log_path)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 1
+
+
+def test_cli_no_verify_skips_chain_check(tmp_path):
+    records = _build_log([BUY1, SELL1])
+    # Tamper second record — but --no-verify should still let it through
+    records[1] = dict(records[1], payload=dict(records[1]["payload"], qty=999.0))
+    log_path = _write_log(tmp_path, records)
+    r = subprocess.run(
+        [sys.executable, _SCRIPT, str(log_path), "--no-verify"],
+        capture_output=True, text=True,
+    )
+    # Should exit 0 (drift check not requested) even with tampered hash
+    assert r.returncode == 0
+
+
+def test_cli_empty_log(tmp_path):
+    log_path = tmp_path / "empty.jsonl"
+    log_path.write_text("", encoding="utf-8")
+    r = subprocess.run(
+        [sys.executable, _SCRIPT, str(log_path)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0
+    assert json.loads(r.stdout) == {}


### PR DESCRIPTION
## What changed

- **`scripts/audit_replay.py`** — new ~175-LOC tool that replays an audit `.jsonl` from an arbitrary start point, feeds every `fill` record through a fresh `PositionTracker`, and outputs the final position snapshot as JSON.
- **`tests/scripts/test_audit_replay.py`** — 24 tests covering all public functions and the CLI.

## Why

E5 from the Phase 8 safety net plan. When a live incident happens we currently have no deterministic way to reconstruct *what the bot actually did* from the audit log. This tool closes that gap: load the log, pick a start point, replay, diff against the stored StateStore snapshot.

## How to use

```bash
# Basic replay — prints final position state as JSON
python scripts/audit_replay.py state/audit.jsonl

# Start from a specific timestamp
python scripts/audit_replay.py state/audit.jsonl --from-ts 2026-05-04T10:00:00

# Compare against a known-good snapshot and detect drift
python scripts/audit_replay.py state/audit.jsonl   --expected state/last_snapshot.json

# Skip hash-chain check (faster on large logs, still replays fills)
python scripts/audit_replay.py state/audit.jsonl --no-verify
```

Exit 0 = no drift. Exit 1 = chain break, drift detected, or parse error.

## Design notes

- Only `fill` records mutate position state; `model_decision` and `risk_event` records are intentionally skipped.
- Drift tolerance is `1e-8` (float rounding noise below that is not a real divergence).
- `--from-hash` accepts a hex prefix (8+ chars is fine) for ergonomic use at the terminal.

## Test coverage

24 tests: chain verify, fill apply, replay identity, non-fill isolation, start-point selection (line/ts/hash), drift detection (numeric/tolerance/missing key), and CLI end-to-end (match, drift, broken chain, `--no-verify`, empty log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)