### PR TITLE
CI: add smoke_train + smoke_walkforward as PR-gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,42 @@ jobs:
         pytest tests/test_full_integration.py -v --tb=short
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Job 3: Lint (black + isort — flake8 advisory only)
+  # Job 3: Smoke tests (training-pipeline regressions unit tests miss)
+  # ──────────────────────────────────────────────────────────────────────────
+  smoke:
+    name: Smoke Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Cache pip
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-3.10-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-3.10-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: smoke_train (short PPO run, 2000 rows)
+      run: python scripts/smoke_train.py
+
+    - name: smoke_walkforward (2-fold WF, 512 timesteps)
+      run: python scripts/smoke_walkforward.py
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Job 4: Lint (black + isort — flake8 advisory only)
   # ──────────────────────────────────────────────────────────────────────────
   lint:
     name: Lint
@@ -141,7 +176,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   deploy-staging:
     name: Deploy → Staging
-    needs: [test, integration, lint]
+    needs: [test, integration, lint, smoke]
     if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
 
@@ -187,7 +222,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   deploy-production:
     name: Deploy → Production
-    needs: [test, integration, lint]
+    needs: [test, integration, lint, smoke]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- `smoke_train.py` + `smoke_walkforward.py` 가 manual-only였음 — PR마다 자동으로 실행되도록 새 `smoke` job 추가
- unit tests가 못 잡는 training-pipeline API/env 버그를 이 두 스크립트가 잡아줌 (feedback_smoke_before_ship 에 기록된 사고 배경)
- `deploy-staging` / `deploy-production` 양쪽 `needs`에 `smoke` 추가 → deploy 전에도 반드시 통과해야 함
- `timeout-minutes: 10` 으로 runaway 방지 (실제 런타임: 각 수십 초)

## Test plan
- [ ] CI 탭에서 `Smoke Tests` job이 `smoke_train` → `smoke_walkforward` 순서로 실행되는지 확인
- [ ] 두 step 모두 초록불인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)