### PR TITLE
E1: extend FaultInjector with 4 new fault probes

### DIFF
--- a/deployment/testing/fault_injector.py
+++ b/deployment/testing/fault_injector.py
@@ -74,6 +74,10 @@ class FaultInjector:
         "clock_skew": -1,                 # random (handled specially)
         "exchange_outage": 18 * 3600,     # I11: 18h
         "spread_blowout": 9 * 3600,       # I11: 9h
+        "symbol_delisted": 48 * 3600,     # E1: 48h
+        "contract_roll": 72 * 3600,       # E1: 72h
+        "data_revision": 48 * 3600,       # E1: 48h
+        "time_alignment_break": 24 * 3600, # E1: 24h
     }
 
     def __init__(
@@ -288,6 +292,99 @@ class FaultInjector:
             evt.safety_net_triggered = True
         else:
             logger.warning("Drill has no _fake_spread_multiplier flag — recording only")
+            evt.safety_net_triggered = False
+
+    def _inject_symbol_delisted(self, evt: FaultEvent) -> None:
+        """Simulate fetch_ticker raising BadSymbol/returning None → position freeze."""
+        logger.warning("[FaultInjector] Injecting symbol_delisted")
+        evt.detail["symbol"] = "SYNTHETIC_DELISTED/USDT"
+        drill = self._drill
+        if hasattr(drill, "_inject_symbol_delisted"):
+            drill._inject_symbol_delisted("SYNTHETIC_DELISTED/USDT")
+            evt.safety_net_triggered = True
+        elif hasattr(drill, "_bad_symbol_flag"):
+            drill._bad_symbol_flag = "SYNTHETIC_DELISTED/USDT"
+            evt.safety_net_triggered = True
+        elif hasattr(drill, "_alerter") and drill._alerter is not None:
+            drill._alerter.notify_error(
+                "BadSymbol: SYNTHETIC_DELISTED/USDT not found on exchange",
+                context="symbol_delisted_fault_inject",
+            )
+            evt.safety_net_triggered = True
+        else:
+            logger.warning("Drill has no symbol delisted mechanism — recording only")
+            evt.safety_net_triggered = False
+
+    def _inject_contract_roll(self, evt: FaultEvent) -> None:
+        """Simulate perp/quarterly contract expiry; N/A flag for spot instruments."""
+        logger.warning("[FaultInjector] Injecting contract_roll")
+        instrument_type = getattr(self._drill, "_instrument_type", "futures")
+        if instrument_type == "spot":
+            evt.detail["skipped_reason"] = "spot_instrument_no_contract_roll"
+            evt.detail["na_flag"] = True
+            evt.safety_net_triggered = False
+            logger.info("[FaultInjector] contract_roll N/A for spot instrument — skipped")
+            return
+        evt.detail["contract"] = "BTCUSDT_quarterly_synthetic"
+        drill = self._drill
+        if hasattr(drill, "_inject_contract_roll"):
+            drill._inject_contract_roll("BTCUSDT_quarterly_synthetic")
+            evt.safety_net_triggered = True
+        elif hasattr(drill, "_fake_contract_roll_flag"):
+            drill._fake_contract_roll_flag = True
+            evt.safety_net_triggered = True
+        elif hasattr(drill, "_alerter") and drill._alerter is not None:
+            drill._alerter.notify_error(
+                "Contract roll detected: BTCUSDT_quarterly_synthetic expiry",
+                context="contract_roll_fault_inject",
+            )
+            evt.safety_net_triggered = True
+        else:
+            logger.warning("Drill has no contract roll mechanism — recording only")
+            evt.safety_net_triggered = False
+
+    def _inject_data_revision(self, evt: FaultEvent) -> None:
+        """Simulate retroactive yfinance price revision (adjusted close −1%)."""
+        logger.warning("[FaultInjector] Injecting data_revision (close −1%)")
+        evt.detail["field"] = "close"
+        evt.detail["revision_pct"] = -1.0
+        drill = self._drill
+        if hasattr(drill, "_inject_data_revision"):
+            drill._inject_data_revision(field="close", revision_pct=-1.0)
+            evt.safety_net_triggered = True
+        elif hasattr(drill, "_fake_price_revision_pct"):
+            drill._fake_price_revision_pct = -1.0
+            evt.safety_net_triggered = True
+        elif hasattr(drill, "_alerter") and drill._alerter is not None:
+            drill._alerter.notify_error(
+                "Retroactive data revision: close adjusted −1.0%",
+                context="data_revision_fault_inject",
+            )
+            evt.safety_net_triggered = True
+        else:
+            logger.warning("Drill has no data revision mechanism — recording only")
+            evt.safety_net_triggered = False
+
+    def _inject_time_alignment_break(self, evt: FaultEvent) -> None:
+        """Simulate holiday forward-fill violation (2h gap in 1h bars)."""
+        logger.warning("[FaultInjector] Injecting time_alignment_break (2h gap in 1h bars)")
+        evt.detail["expected_bar_seconds"] = 3600
+        evt.detail["actual_gap_seconds"] = 7200
+        drill = self._drill
+        if hasattr(drill, "_inject_time_alignment_break"):
+            drill._inject_time_alignment_break(expected_bar_seconds=3600, actual_gap_seconds=7200)
+            evt.safety_net_triggered = True
+        elif hasattr(drill, "_fake_bar_gap_seconds"):
+            drill._fake_bar_gap_seconds = 7200
+            evt.safety_net_triggered = True
+        elif hasattr(drill, "_alerter") and drill._alerter is not None:
+            drill._alerter.notify_error(
+                "Time alignment break: 7200s gap in 1h bars (expected 3600s)",
+                context="time_alignment_break_fault_inject",
+            )
+            evt.safety_net_triggered = True
+        else:
+            logger.warning("Drill has no time alignment mechanism — recording only")
             evt.safety_net_triggered = False
 
     # ------------------------------------------------------------------

--- a/tests/scripts/test_fault_injector.py
+++ b/tests/scripts/test_fault_injector.py
@@ -67,6 +67,18 @@ class _MockDrill:
     def _pause_feed(self, seconds: float) -> None:
         self.injected_calls.append(("feed_stale", seconds))
 
+    def _inject_symbol_delisted(self, symbol: str) -> None:
+        self.injected_calls.append(("symbol_delisted", symbol))
+
+    def _inject_contract_roll(self, contract: str) -> None:
+        self.injected_calls.append(("contract_roll", contract))
+
+    def _inject_data_revision(self, field: str, revision_pct: float) -> None:
+        self.injected_calls.append(("data_revision", field, revision_pct))
+
+    def _inject_time_alignment_break(self, expected_bar_seconds: int, actual_gap_seconds: int) -> None:
+        self.injected_calls.append(("time_alignment_break", expected_bar_seconds, actual_gap_seconds))
+
 
 def _make_alerter(tmp_path: pathlib.Path):
     from deployment.monitoring.alerter import TradingAlerter
@@ -269,3 +281,81 @@ def test_exchange_outage_and_spread_blowout_in_default_intervals() -> None:
     assert "spread_blowout" in FaultInjector.DEFAULT_INTERVALS
     assert FaultInjector.DEFAULT_INTERVALS["exchange_outage"] == 18 * 3600
     assert FaultInjector.DEFAULT_INTERVALS["spread_blowout"] == 9 * 3600
+
+
+# ---------------------------------------------------------------------------
+# E1: symbol_delisted / contract_roll / data_revision / time_alignment_break
+# ---------------------------------------------------------------------------
+
+def test_inject_symbol_delisted(tmp_path: pathlib.Path) -> None:
+    """symbol_delisted: calls drill._inject_symbol_delisted and sets safety_net_triggered."""
+    from deployment.testing.fault_injector import FaultInjector
+
+    drill = _MockDrill(tmp_path)
+    fi = FaultInjector(drill=drill, log_path=tmp_path / "faults.jsonl")
+    evt = fi.inject_now("symbol_delisted")
+    assert evt.safety_net_triggered
+    assert any(c[0] == "symbol_delisted" for c in drill.injected_calls)
+    assert evt.detail["symbol"] == "SYNTHETIC_DELISTED/USDT"
+
+
+def test_inject_contract_roll_futures(tmp_path: pathlib.Path) -> None:
+    """contract_roll: futures instrument triggers _inject_contract_roll on drill."""
+    from deployment.testing.fault_injector import FaultInjector
+
+    drill = _MockDrill(tmp_path)
+    drill._instrument_type = "futures"
+    fi = FaultInjector(drill=drill, log_path=tmp_path / "faults.jsonl")
+    evt = fi.inject_now("contract_roll")
+    assert evt.safety_net_triggered
+    assert any(c[0] == "contract_roll" for c in drill.injected_calls)
+
+
+def test_inject_contract_roll_spot_na(tmp_path: pathlib.Path) -> None:
+    """contract_roll: spot instrument sets na_flag and skips safety net trigger."""
+    from deployment.testing.fault_injector import FaultInjector
+
+    drill = _MockDrill(tmp_path)
+    drill._instrument_type = "spot"
+    fi = FaultInjector(drill=drill, log_path=tmp_path / "faults.jsonl")
+    evt = fi.inject_now("contract_roll")
+    assert not evt.safety_net_triggered
+    assert evt.detail.get("na_flag") is True
+    assert not any(c[0] == "contract_roll" for c in drill.injected_calls)
+
+
+def test_inject_data_revision(tmp_path: pathlib.Path) -> None:
+    """data_revision: calls drill._inject_data_revision with field and revision_pct."""
+    from deployment.testing.fault_injector import FaultInjector
+
+    drill = _MockDrill(tmp_path)
+    fi = FaultInjector(drill=drill, log_path=tmp_path / "faults.jsonl")
+    evt = fi.inject_now("data_revision")
+    assert evt.safety_net_triggered
+    assert any(c[0] == "data_revision" for c in drill.injected_calls)
+    assert evt.detail["field"] == "close"
+    assert evt.detail["revision_pct"] == -1.0
+
+
+def test_inject_time_alignment_break(tmp_path: pathlib.Path) -> None:
+    """time_alignment_break: reports 2h gap in 1h bars via _inject_time_alignment_break."""
+    from deployment.testing.fault_injector import FaultInjector
+
+    drill = _MockDrill(tmp_path)
+    fi = FaultInjector(drill=drill, log_path=tmp_path / "faults.jsonl")
+    evt = fi.inject_now("time_alignment_break")
+    assert evt.safety_net_triggered
+    assert any(c[0] == "time_alignment_break" for c in drill.injected_calls)
+    assert evt.detail["expected_bar_seconds"] == 3600
+    assert evt.detail["actual_gap_seconds"] == 7200
+
+
+def test_e1_faults_in_default_intervals() -> None:
+    """E1: All four new faults appear in DEFAULT_INTERVALS with expected values."""
+    from deployment.testing.fault_injector import FaultInjector
+
+    d = FaultInjector.DEFAULT_INTERVALS
+    assert d["symbol_delisted"] == 48 * 3600
+    assert d["contract_roll"] == 72 * 3600
+    assert d["data_revision"] == 48 * 3600
+    assert d["time_alignment_break"] == 24 * 3600


### PR DESCRIPTION
## Summary
- Adds `symbol_delisted`, `contract_roll`, `data_revision`, `time_alignment_break` handlers to `FaultInjector`
- `contract_roll` is N/A-flagged (no safety net trigger) when `drill._instrument_type == "spot"` — covers futures-only scenario cleanly
- Each handler follows the existing `_inject_<name>` dispatch: drill method → flag attribute → alerter fallback → warning
- `DEFAULT_INTERVALS`: 48h / 72h / 48h / 24h respectively

## Test plan
- [x] 6 new unit tests (19 total): one per handler + `contract_roll` spot N/A path + `DEFAULT_INTERVALS` membership check
- [x] All 19 tests pass (`pytest tests/scripts/test_fault_injector.py -v`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)