### PR TITLE
chore: gitignore Claude tooling dirs + __pycache__ fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python related
 **pycache**/
+__pycache__/
 *.pyc
 *.egg-info/
 .pytest_cache/
@@ -27,6 +28,8 @@ data/
 # tests/data/ is test code, not data — always track
 !tests/data/
 !tests/data/**
+# ...but still ignore bytecode caches inside tests/data/
+tests/data/__pycache__/
 
 # Docker
 docker/
@@ -78,6 +81,11 @@ test_checkpoints_multi/
 
 # Specstory (as requested)
 .specstory/
+
+# Claude Code tooling (worktrees, session state, HUD)
+.claude/worktrees/
+.claire/
+.omx/
 
 # Large files
 *.pt


### PR DESCRIPTION
## Summary

- `.claude/worktrees/`, `.claire/`, `.omx/` — Claude Code session artifacts; should never be tracked
- `__pycache__/` — explicit pattern added because existing `**pycache**/` misses the leading `__` prefix
- `tests/data/__pycache__/` — override to re-ignore bytecodes inside `tests/data/`, which is otherwise un-ignored by the `!tests/data/**` rule

## Why now

After E6/E7 (PR #131), `git status` showed several noise entries from Claude tooling. Clean this up first so subsequent PRs have a clear `git status`.

## Test plan
- [ ] `git status` on main after merge shows none of the noise entries
- [ ] `tests/data/` source files still tracked
- [ ] CI green

Generated with Claude Code