### PR TITLE
misc: alerter Discord User-Agent + Phase 7 evidence backfill

### DIFF
--- a/deployment/monitoring/alerter.py
+++ b/deployment/monitoring/alerter.py
@@ -494,7 +494,10 @@ class TradingAlerter:
             req = urllib.request.Request(
                 self._discord_url,
                 data=payload,
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": "DiscordBot (trading-bot, 1.0)",
+                },
                 method="POST",
             )
             with urllib.request.urlopen(req, timeout=10) as resp:

--- a/docs/phase7.6/live_drill_20260426T165824Z.md
+++ b/docs/phase7.6/live_drill_20260426T165824Z.md
@@ -1,0 +1,19 @@
+# Live Drill Report — 20260426T165824Z
+
+**Symbol**: BTC/USDT  
+**Capital**: $100  
+**Notional**: $50  
+**Limit price**: 49049.0 (mid 50050.00 × 0.98)  
+**Fill status**: cancelled  
+**Elapsed**: 0.0s  
+
+## Balance
+
+| | Pre | Post | Diff |
+|---|---|---|---|
+| USDT | 1000.00 | 1000.00 | +0.00 |
+| BTC  | 0.00000000 | 0.00000000 | +0.00000000 |
+
+## Audit Chain
+
+✅ intact

--- a/docs/phase7.6/live_drill_20260427T175217Z.md
+++ b/docs/phase7.6/live_drill_20260427T175217Z.md
@@ -1,0 +1,38 @@
+# Live Drill Report — 20260427T175217Z
+
+**Symbol**: BTC/USDT  
+**Capital**: $100  
+**Notional**: $50  
+**Limit price**: 49049.0 (mid 50050.00 × 0.98)  
+**Fill status**: cancelled  
+**Elapsed**: 0.0s  
+
+## Balance
+
+| | Pre | Post | Diff |
+|---|---|---|---|
+| USDT | 1000.00 | 1000.00 | +0.00 |
+| BTC  | 0.00000000 | 0.00000000 | +0.00000000 |
+
+## Latency
+
+| Stage | Latency |
+|-------|---------|
+| Submit → ack | 0ms |
+| Ack → fill/cancel | 0ms |
+
+## Slippage
+
+| | Predicted | Actual |
+|---|---|---|
+| Slippage | 0.0000% | 2.0979% |
+
+## Fee
+
+| | Config | Actual |
+|---|---|---|
+| Fee | $0.0500 | $0.0500 |
+
+## Audit Chain
+
+✅ intact

--- a/docs/phase7.6/live_drill_20260427T175741Z.md
+++ b/docs/phase7.6/live_drill_20260427T175741Z.md
@@ -1,0 +1,38 @@
+# Live Drill Report — 20260427T175741Z
+
+**Symbol**: BTC/USDT  
+**Capital**: $100  
+**Notional**: $50  
+**Limit price**: 49049.0 (mid 50050.00 × 0.98)  
+**Fill status**: cancelled  
+**Elapsed**: 0.0s  
+
+## Balance
+
+| | Pre | Post | Diff |
+|---|---|---|---|
+| USDT | 1000.00 | 1000.00 | +0.00 |
+| BTC  | 0.00000000 | 0.00000000 | +0.00000000 |
+
+## Latency
+
+| Stage | Latency |
+|-------|---------|
+| Submit → ack | 0ms |
+| Ack → fill/cancel | 0ms |
+
+## Slippage
+
+| | Predicted | Actual |
+|---|---|---|
+| Slippage | 0.0000% | 2.0979% |
+
+## Fee
+
+| | Config | Actual |
+|---|---|---|
+| Fee | $0.0500 | $1.0000 |
+
+## Audit Chain
+
+✅ intact

--- a/docs/phase7/week85_72h_20260423.md
+++ b/docs/phase7/week85_72h_20260423.md
@@ -1,0 +1,31 @@
+# 72h Autonomous Drill — Final Report
+
+**Start**: 2026-04-23 16:28 UTC  
+**Duration**: 0.00h  
+**Feed**: ws  
+
+---
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total ticks | 7 |
+| Safety net halts | 0 |
+| Auto-resumes | 0 |
+| Faults injected | 0 |
+| Max halt duration | 0.0s |
+
+## Fault Injection Summary
+
+| Fault Type | Count |
+|------------|-------|
+| none | 0 |
+
+---
+
+## Sign-off
+
+- [ ] Operator reviewed all incidents
+- [ ] Drift calibration run: `python scripts/analyze_drift_baseline.py`
+- [ ] No kill-switch odfires during shadow mode

--- a/docs/phase7/week85_72h_20260426.md
+++ b/docs/phase7/week85_72h_20260426.md
@@ -1,0 +1,128 @@
+# 72h Autonomous Drill — Final Report
+
+**Start**: 2026-04-26 02:33 UTC  
+**Duration**: 72.00h  
+**Feed**: auto  
+
+---
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total ticks | 398584 |
+| Safety net halts | 0 |
+| Auto-resumes | 0 |
+| Faults injected | 65 |
+| Max halt duration | 0.0s |
+
+## Fault Injection Summary
+
+| Fault Type | Count |
+|------------|-------|
+| clock_skew | 47 |
+| feed_stale | 11 |
+| canary_underperform | 11 |
+| reconciliation_mismatch | 5 |
+| schema_drift | 2 |
+
+## Observation Table (15-min snapshots)
+
+| Time (elapsed h) | Portfolio Value | Price | Halts | Faults |
+|-----------------|----------------|-------|-------|--------|
+| 67.23 | 15974.13 | 42402.99 | 0 | 62 |
+| 67.48 | 18389.94 | 49558.34 | 0 | 62 |
+| 67.74 | 22121.17 | 76343.89 | 0 | 63 |
+| 67.99 | 15644.13 | 41814.90 | 0 | 63 |
+| 68.24 | 21021.94 | 76281.33 | 0 | 63 |
+| 68.49 | 23022.81 | 76211.21 | 0 | 63 |
+| 68.74 | 23170.98 | 76334.02 | 0 | 63 |
+| 68.99 | 13635.23 | 33766.44 | 0 | 63 |
+| 69.24 | 23526.07 | 76327.52 | 0 | 63 |
+| 69.49 | 23743.10 | 76347.85 | 0 | 64 |
+| 69.74 | 24520.21 | 76300.01 | 0 | 64 |
+| 69.99 | 15255.21 | 31019.21 | 0 | 64 |
+| 70.24 | 18453.33 | 34140.41 | 0 | 64 |
+| 70.49 | 26534.68 | 76524.15 | 0 | 64 |
+| 70.74 | 26207.45 | 76298.21 | 0 | 64 |
+| 70.99 | 19783.26 | 35496.50 | 0 | 64 |
+| 71.24 | 20752.12 | 41806.41 | 0 | 64 |
+| 71.49 | 25560.93 | 76523.32 | 0 | 65 |
+| 71.74 | 20464.97 | 34753.17 | 0 | 65 |
+| 72.00 | 20283.12 | 30592.15 | 0 | 65 |
+
+## Incidents
+
+- **20260426T041851** `clock_skew` — {"skew_seconds": 10}
+- **20260426T061946** `clock_skew` — {"skew_seconds": 10}
+- **20260426T074025** `clock_skew` — {"skew_seconds": 10}
+- **20260426T084818** `canary_underperform` — {"sigma_below": 1.5}
+- **20260426T091119** `clock_skew` — {"skew_seconds": 10}
+- **20260426T102905** `clock_skew` — {"skew_seconds": 10}
+- **20260426T120402** `clock_skew` — {"skew_seconds": 10}
+- **20260426T135100** `clock_skew` — {"skew_seconds": 10}
+- **20260426T143353** `reconciliation_mismatch` — {"qty_drift_pct": 1.5}
+- **20260426T144818** `canary_underperform` — {"sigma_below": 1.5}
+- **20260426T150036** `clock_skew` — {"skew_seconds": 10}
+- **20260426T165612** `clock_skew` — {"skew_seconds": 10}
+- **20260426T180436** `clock_skew` — {"skew_seconds": 10}
+- **20260426T192659** `clock_skew` — {"skew_seconds": 10}
+- **20260426T204820** `canary_underperform` — {"sigma_below": 1.5}
+- **20260426T210014** `clock_skew` — {"skew_seconds": 10}
+- **20260426T221513** `clock_skew` — {"skew_seconds": 10}
+- **20260426T234819** `clock_skew` — {"skew_seconds": 10}
+- **20260427T011442** `clock_skew` — {"skew_seconds": 10}
+- **20260427T022837** `clock_skew` — {"skew_seconds": 10}
+- **20260427T023355** `reconciliation_mismatch` — {"qty_drift_pct": 1.5}
+- **20260427T023355** `schema_drift` — {"column": "synthetic_feature_fault"}
+- **20260427T024821** `canary_underperform` — {"sigma_below": 1.5}
+- **20260427T033749** `clock_skew` — {"skew_seconds": 10}
+- **20260427T044652** `clock_skew` — {"skew_seconds": 10}
+- **20260427T055533** `clock_skew` — {"skew_seconds": 10}
+- **20260427T073124** `clock_skew` — {"skew_seconds": 10}
+- **20260427T085431** `canary_underperform` — {"sigma_below": 1.5}
+- **20260427T092753** `clock_skew` — {"skew_seconds": 10}
+- **20260427T111221** `clock_skew` — {"skew_seconds": 10}
+- **20260427T130627** `clock_skew` — {"skew_seconds": 10}
+- **20260427T140958** `clock_skew` — {"skew_seconds": 10}
+- **20260427T143358** `reconciliation_mismatch` — {"qty_drift_pct": 1.5}
+- **20260427T145433** `canary_underperform` — {"sigma_below": 1.5}
+- **20260427T151750** `clock_skew` — {"skew_seconds": 10}
+- **20260427T165522** `clock_skew` — {"skew_seconds": 10}
+- **20260427T182757** `clock_skew` — {"skew_seconds": 10}
+- **20260427T201040** `clock_skew` — {"skew_seconds": 10}
+- **20260427T205440** `canary_underperform` — {"sigma_below": 1.5}
+- **20260427T214405** `clock_skew` — {"skew_seconds": 10}
+- **20260427T232149** `clock_skew` — {"skew_seconds": 10}
+- **20260428T011101** `clock_skew` — {"skew_seconds": 10}
+- **20260428T023400** `reconciliation_mismatch` — {"qty_drift_pct": 1.5}
+- **20260428T023400** `schema_drift` — {"column": "synthetic_feature_fault"}
+- **20260428T025440** `canary_underperform` — {"sigma_below": 1.5}
+- **20260428T025817** `clock_skew` — {"skew_seconds": 10}
+- **20260428T044913** `clock_skew` — {"skew_seconds": 10}
+- **20260428T064617** `clock_skew` — {"skew_seconds": 10}
+- **20260428T080454** `clock_skew` — {"skew_seconds": 10}
+- **20260428T085441** `canary_underperform` — {"sigma_below": 1.5}
+- **20260428T090507** `clock_skew` — {"skew_seconds": 10}
+- **20260428T110108** `clock_skew` — {"skew_seconds": 10}
+- **20260428T124931** `clock_skew` — {"skew_seconds": 10}
+- **20260428T140026** `clock_skew` — {"skew_seconds": 10}
+- **20260428T143852** `reconciliation_mismatch` — {"qty_drift_pct": 1.5}
+- **20260428T145901** `canary_underperform` — {"sigma_below": 1.5}
+- **20260428T152335** `clock_skew` — {"skew_seconds": 10}
+- **20260428T170551** `clock_skew` — {"skew_seconds": 10}
+- **20260428T181441** `clock_skew` — {"skew_seconds": 10}
+- **20260428T192618** `clock_skew` — {"skew_seconds": 10}
+- **20260428T204218** `clock_skew` — {"skew_seconds": 10}
+- **20260428T205544** `canary_underperform` — {"sigma_below": 1.5}
+- **20260428T220505** `clock_skew` — {"skew_seconds": 10}
+- **20260428T235313** `clock_skew` — {"skew_seconds": 10}
+- **20260429T015233** `clock_skew` — {"skew_seconds": 10}
+
+---
+
+## Sign-off
+
+- [ ] Operator reviewed all incidents
+- [ ] Drift calibration run: `python scripts/analyze_drift_baseline.py`
+- [ ] No kill-switch odfires during shadow mode

--- a/docs/runbook/key_scope_report_20260427.md
+++ b/docs/runbook/key_scope_report_20260427.md
@@ -1,8 +1,8 @@
-# API Key Scope Report — 20260423
+# API Key Scope Report — 20260427
 
 **Exchange**: binance  
 **Mode**: sandbox/testnet  
-**Timestamp**: 2026-04-23T16:26:39.468719+00:00  
+**Timestamp**: 2026-04-27T17:57:41.456704+00:00  
 **Result**: ✅ ALL PROBES PASSED
 
 ## Probe Results


### PR DESCRIPTION
## Summary

**alerter.py**: Add `User-Agent: DiscordBot (trading-bot, 1.0)` header to Discord webhook requests. Discord rejects some requests without it.

**Phase 7 evidence docs** (generated locally, never committed):
- `docs/phase7.6/live_drill_2026042[67]*.md` — 3 drill postmortems
- `docs/phase7/week85_72h_2026042[36].md` — 2 Week 85 72h run logs
- `docs/runbook/key_scope_report_20260427.md` — new scope report
- `docs/runbook/key_scope_report_20260423.md` — timestamp update from re-run

No behavioral changes to trading logic. No new tests needed (alerter change is 3 lines in a header dict).

## Notes

- `tests/test_ppo_advantage_update.py` is intentionally excluded — red (`buffers.ppo_buffer` module missing from main). Left untracked pending author/source clarification.
- Plan 2 (E8) follows separately per phase8-track-e6-e7-tax-key.md plan.

## Test plan
- [ ] CI green
- [ ] Discord alert fires correctly with new header (manual verification at next drill)

Generated with Claude Code