### PR TITLE
docs(phase8): empirical reward-stream diagnostic for Phase 8-Beta v2

### DIFF
--- a/docs/phase8/reward_stream_dump.md
+++ b/docs/phase8/reward_stream_dump.md
@@ -1,0 +1,51 @@
+# Phase 8-Beta §0 — Empirical reward stream dump
+
+**Date**: 2026-05-05
+**Script**: `scripts/diagnostic_reward_stream.py`
+**Purpose**: empirically confirm the §0 diagnosis of the Phase 8-Beta plan before handing to Sonnet for code work.
+
+## Setup
+
+- Env: `SingleAssetRLTradingEnv` with futures_maker config (trading_fee=0.018%, no slippage, cost_model=futures_maker, funding_rate_per_8h=0.0001, hourly data, sharpe_lookback=60, sharpe_weight=0.1, drawdown_penalty_threshold=0.1, min_episode_steps=30).
+- Data: `data/raw/BTCUSDT_1h.csv` (8760 rows, 1h bars). 200-bar slices.
+- Three deterministic policies + a "worst drawdown slice" scan.
+
+## Results
+
+| Policy | Steps | Trades | Total reward | basic (sum) | sharpe_proxy raw (sum) | drawdown_penalty (sum) |
+|---|---|---|---|---|---|---|
+| P1 hold-only (bull slice) | 200 | 0 | **0.000** | 0.000 | 0.0 | 0.000 |
+| P2 buy-and-hold (bull, terminated) | 31 | 1 | **−28.00** | −0.0005 | −280.0 (≈ −9.03/step) | 0.000 |
+| P3 buy-and-hold (worst-drawdown slice) | 31 | 1 | **−28.00** | −0.0004 | −280.0 (≈ −9.03/step) | 0.000 |
+| P4 active flip every 10 bars | 42 | 9 | **−39.00** | −0.0015 | −390.0 (≈ −9.29/step) | 0.000 |
+
+(Sharpe column shows raw `sharpe_proxy` summed; final-reward contribution = `0.1 × sharpe_proxy`. The clip is ±10, weight 0.1, so per-step contribution is in ±1.0.)
+
+## Key findings
+
+1. **Hold-only confirms reward floor = 0**. 200 steps, all components 0. Returns buffer stays at 0, sharpe stays at 0, drawdown stays at 0.
+
+2. **Sharpe component is the dominant negative force when in position**. Per-step sharpe_proxy averages −9.0 to −9.3 — i.e. saturated at the −10 clip almost every step. Weighted contribution ≈ −0.9 to −1.0 per step, accumulating to −28 over 31 steps and −39 over 42 steps.
+
+3. **Drawdown penalty is effectively 0 in typical training episodes**. Across P2/P3/P4, drawdown never reached the 10% threshold within the 31-42 forced-termination window, so the penalty contributed exactly 0. v1 plan's "softer drawdown" variant would have had **zero observable effect** at this episode length.
+
+4. **Sharpe penalty is invariant to trade frequency**. P2 (1 trade) and P4 (9 trades) accumulate the same per-step sharpe drag. Trade count itself does not modulate this lever.
+
+5. **Episodes terminate early when in position** (31-42 steps vs P1's full 200). Likely stop-loss or capital-exhaustion check tripping under the saturated negative reward + small adverse moves. The agent observes: "stay flat = 200 steps × 0 reward; take position = 30-40 steps × −1 reward and forced exit." Optimal policy is to stay flat.
+
+## Implications for plan §2 variants
+
+v1 had three primary variants (inactivity, softer-drawdown, combined). v2 corrects this:
+
+- **Drop softer-drawdown variant entirely** — empirical contribution is 0 in training-length episodes.
+- **Add sharpe-weight reduction (0.1 → 0.02)** as the dominant uniform-reduction lever.
+- **Add sharpe-clip narrowing (±10 → ±2)** as the dominant saturation-only lever.
+- **Keep inactivity penalty** as a clean 0-floor-breaking lever (caveat: alone it is 100× smaller than sharpe drag, so unlikely to be sufficient in isolation).
+
+## Reproducibility
+
+```bash
+PYTHONPATH=. python scripts/diagnostic_reward_stream.py
+```
+
+Deterministic given the same data file. Outputs vary by ≤ float tolerance.

--- a/scripts/diagnostic_reward_stream.py
+++ b/scripts/diagnostic_reward_stream.py
@@ -1,0 +1,137 @@
+"""Empirical reward-stream confirmation for Phase 8-Beta plan §0.
+
+Three policies on a 250-bar BTC slice with futures_maker-style env:
+  P1: hold-only (action=0 every step)
+  P2: buy-and-hold (action=+1 step 0, then 0)
+  P3: buy-then-let-drawdown (action=+1 step 0, hold; show drawdown_penalty kicking in)
+"""
+
+import os
+import sys
+import numpy as np
+import pandas as pd
+
+from envs.single_asset_rl_env import SingleAssetRLTradingEnv
+
+# Prefer full ~8760-row data if available; fall back to 200-row test sample.
+_CANDIDATE_PATHS = [
+    "/Users/skylar/Desktop/trading_bot/.claude/worktrees/laughing-benz-3e8884/data/raw/BTCUSDT_1h.csv",
+    "/Users/skylar/Desktop/trading_bot/data/BTCUSDT_1h.csv",
+]
+DATA_PATH = next((p for p in _CANDIDATE_PATHS if os.path.exists(p)), _CANDIDATE_PATHS[-1])
+
+
+def make_env(slice_start: int, slice_len: int = 250):
+    df = pd.read_csv(DATA_PATH, index_col=0, parse_dates=True)
+    df = df.iloc[slice_start : slice_start + slice_len].reset_index(drop=True)
+    return SingleAssetRLTradingEnv(
+        data=df,
+        initial_capital=100000.0,
+        trading_fee=0.00018,
+        window_size=20,
+        max_position_size=1.0,
+        sharpe_lookback=60,
+        sharpe_weight=0.1,
+        risk_adjusted_reward=True,
+        drawdown_penalty=True,
+        max_drawdown_penalty_threshold=0.1,
+        apply_slippage=False,
+        slippage_factor=0.0,
+        partial_fills=False,
+        cost_model="futures_maker",
+        funding_rate_per_8h=0.0001,
+        data_frequency="hourly",
+        min_episode_steps=30,
+    )
+
+
+def run_policy(name: str, slice_start: int, action_fn, n_steps: int = 200):
+    env = make_env(slice_start)
+    obs, _ = env.reset()
+    total = 0.0
+    components = {"basic": 0.0, "sharpe": 0.0, "drawdown_penalty": 0.0}
+    n_trades = 0
+    last_position = 0.0
+    dd_hits = 0
+    rewards = []
+    for t in range(n_steps):
+        a = action_fn(t)
+        obs, r, term, trunc, info = env.step(np.array([a], dtype=np.float32))
+        rewards.append(r)
+        total += r
+        rd = info.get("reward_debug", {})
+        components["basic"] += rd.get("basic_reward", 0.0)
+        components["sharpe"] += rd.get("sharpe_component", 0.0)
+        dd = rd.get("drawdown_penalty", 0.0)
+        components["drawdown_penalty"] += dd
+        if dd < -1e-9:
+            dd_hits += 1
+        pos = float(env.current_position)
+        if abs(pos - last_position) > 1e-6:
+            n_trades += 1
+            last_position = pos
+        if term or trunc:
+            break
+    final_pv = float(env.portfolio_value)
+    print(f"\n=== {name} (slice_start={slice_start}, steps={t+1}) ===")
+    print(f"  Final portfolio: ${final_pv:,.2f}  (return {(final_pv/100000-1)*100:+.2f}%)")
+    print(f"  Trades:          {n_trades}")
+    print(f"  Total reward:    {total:+.6f}")
+    print(f"  Components (sum): basic={components['basic']:+.6f}  "
+          f"sharpe_proxy={components['sharpe']:+.4f}  "
+          f"drawdown_penalty={components['drawdown_penalty']:+.4f}")
+    print(f"  Drawdown-penalty steps: {dd_hits}/{t+1}")
+    print(f"  Reward stats: mean={np.mean(rewards):+.6f}  "
+          f"std={np.std(rewards):.6f}  "
+          f"min={np.min(rewards):+.6f}  max={np.max(rewards):+.6f}")
+    return total, components, n_trades, dd_hits
+
+
+# Pick 3 slices: bull, bear, choppy. From BTCUSDT_1h.csv (2024-05 onward, 17000+ rows).
+# 2024-05 -> ~ +50% bull rally over ~2k bars
+# 2025-Q3 area should be sideways/bear
+
+# Bull slice: rows 0-250 (2024-05 early)
+# Drawdown slice: pick a slice with a known dump — try several offsets
+
+print("Phase 8-Beta §0 empirical reward dump")
+print("=" * 60)
+
+# P1: hold-only on bull slice
+run_policy("P1 hold-only (bull slice)", slice_start=100, action_fn=lambda t: 0.0)
+
+# P2: buy-and-hold on bull slice
+run_policy(
+    "P2 buy-and-hold (bull slice)",
+    slice_start=100,
+    action_fn=lambda t: 1.0 if t == 0 else 0.0,
+)
+
+# P3: buy-and-hold on a drawdown slice — find one
+# Scan for a 200-bar window with big peak-to-trough drop
+df_full = pd.read_csv(DATA_PATH, index_col=0, parse_dates=True)
+closes = df_full["$close"].values
+window = 200
+worst_dd = 0.0
+worst_idx = 0
+for i in range(0, len(closes) - window, 50):
+    seg = closes[i : i + window]
+    peak = np.maximum.accumulate(seg)
+    dd = ((peak - seg) / peak).max()
+    if dd > worst_dd:
+        worst_dd = dd
+        worst_idx = i
+print(f"\n[Worst 200-bar drawdown found: {worst_dd*100:.1f}% at row {worst_idx}]")
+
+run_policy(
+    "P3 buy-and-hold (worst drawdown slice)",
+    slice_start=worst_idx,
+    action_fn=lambda t: 1.0 if t == 0 else 0.0,
+)
+
+# P4: alternating buy/sell — emulate active trader to see fee impact
+run_policy(
+    "P4 active trader (flip every 10 bars, bull slice)",
+    slice_start=100,
+    action_fn=lambda t: 1.0 if (t // 10) % 2 == 0 else -1.0,
+)


### PR DESCRIPTION
## Summary

- Adds `scripts/diagnostic_reward_stream.py` — reproducible reward-component dump on 4 deterministic policies (hold-only, buy-and-hold, drawdown slice, active flip)
- Adds `docs/phase8/reward_stream_dump.md` — results table + diagnosis driving Phase 8-Beta v2 variant set

## Why

Phase 8-Beta v1 plan (in `~/.claude/plans/phase8-beta-reward-shaping.md`) assumed `drawdown_penalty` was the primary lever causing the near-hold policy observed in Phase 8-Alpha v3 (1-2 trades/ep). An empirical reward-stream dump on the futures_maker env disconfirmed that:

| Policy | Steps | Total reward | sharpe (weighted) | drawdown_penalty |
|---|---|---|---|---|
| hold-only | 200 | 0.000 | 0.0 | 0.000 |
| buy-and-hold (bull) | 31 (forced exit) | -28.0 | -28.0 | 0.000 |
| buy-and-hold (worst-dd slice) | 31 | -28.0 | -28.0 | 0.000 |
| active flip every 10 bars | 42 | -39.0 | -39.0 | 0.000 |

Sharpe component is **fully saturated at the ±10 clip** almost every step a position is open (annualization factor ~93.6 dominates), contributing ~-1.0/step weighted. Drawdown penalty contribution is **literally 0** in typical 31-42 step training episodes (10% threshold never reached). This reverses v1's primary-lever assumption.

Plan has been updated to v2 with a new variant set (B0 baseline / B1 inactivity / B2 sharpe_weight 0.1->0.02 / B3 sharpe_clip ±10->±2). The "softer drawdown" variant from v1 was dropped because empirical contribution is 0.

## Reviewer notes

- This PR ships only the diagnostic + evidence file, no env or training-pipeline changes.
- The Phase 8-Beta Stage 1 code work (env knobs `inactivity_penalty` and `sharpe_clip_value`, tests, configs) is a separate upcoming PR on branch `claude/phase8-beta-reward-ablation`.
- Reproduce locally: `PYTHONPATH=. python scripts/diagnostic_reward_stream.py` (deterministic given the BTC data file).
- Script auto-resolves data path: prefers the 8760-row file if present, falls back to the 200-row test sample.

## Test plan

- [x] Diagnostic runs end-to-end and prints all 4 policy summaries
- [x] Pre-commit hooks pass (detect-secrets, trim whitespace, etc.)
- [ ] Reviewer can reproduce the table by running the script

Generated with [Claude Code](https://claude.com/claude-code)
