### PR TITLE
feat(phase8-gamma): G1 HMM regime gate — diagnostic Step 2

### DIFF
--- a/config/phase8_gamma/G1_regime_gate.yaml
+++ b/config/phase8_gamma/G1_regime_gate.yaml
@@ -1,0 +1,52 @@
+# Phase 8-Gamma G1 diagnostic — HMM regime gate on top of futures_maker baseline
+# Inherits from base.yaml + futures_maker.yaml semantics; adds regime_gate config.
+# Diagnostic-stage simplifications (intentional, see plan §2):
+#   1. HMM fitted on full data (leakage caveat)
+#   2. Hard gate via argmax or threshold (no soft scaling)
+#   3. Gate implemented directly in env step (bypasses buggy adjust_for_regime)
+
+env:
+  type: single_asset_rl
+  window_size: 20
+  initial_balance: 100000.0
+  trading_fee: 0.00018
+  apply_slippage: false
+  slippage_factor: 0.0
+  cost_model: futures_maker
+  funding_rate_per_8h: 0.0001
+  max_position_size: 1.0
+  sharpe_lookback: 60
+  sharpe_weight: 0.1
+  normalize: true
+  reward_function: sharpe_ratio
+  action_type: continuous
+  include_technical_indicators: true
+  risk_adjusted: true
+  realistic_slippage: false
+
+  # Phase 8-Gamma G1 — HMM regime gate
+  regime_gate:
+    enabled: true
+    mode: close                # "close" forces flat in bear; "refuse_entry" only blocks new longs
+    bear_threshold: 0.5        # min bear posterior prob to trigger gate; 0.0 = argmax mode
+    detector:
+      n_regimes: 3
+      lookback: 60
+      vol_window: 20
+      n_iter: 100
+      random_state: 42
+
+  indicators:
+    - name: RSI
+      window: 14
+    - name: MACD
+      fast_window: 12
+      slow_window: 26
+      signal_window: 9
+    - name: Bollinger
+      window: 20
+      dev: 2
+
+walk_forward:
+  random_start_eval: true
+  eval_episodes: 20

--- a/config/schema.py
+++ b/config/schema.py
@@ -70,6 +70,25 @@ class EnvConfig(BaseModel):
             raise ValueError(f"sharpe_clip_value must be in (0, 100], got {v}")
         return v
 
+    # Phase 8-Gamma G1: regime gate knobs (nested regime_gate dict is extra="allow")
+    regime_gate_enabled: bool = False
+    regime_gate_mode: str = "close"
+    regime_gate_bear_threshold: float = 0.5
+
+    @field_validator("regime_gate_mode")
+    @classmethod
+    def regime_gate_mode_valid(cls, v: str) -> str:
+        if v not in ("close", "refuse_entry"):
+            raise ValueError(f"regime_gate_mode must be 'close' or 'refuse_entry', got '{v}'")
+        return v
+
+    @field_validator("regime_gate_bear_threshold")
+    @classmethod
+    def regime_gate_bear_threshold_range(cls, v: float) -> float:
+        if not (0.0 <= v <= 1.0):
+            raise ValueError(f"regime_gate_bear_threshold must be in [0, 1], got {v}")
+        return v
+
 
 class AgentConfig(BaseModel):
     model_config = ConfigDict(extra="allow")

--- a/envs/single_asset_rl_env.py
+++ b/envs/single_asset_rl_env.py
@@ -91,6 +91,11 @@ class SingleAssetRLTradingEnv(gym.Env):
         # Phase 8-Beta: reward shaping knobs
         inactivity_penalty: float = 0.0,
         sharpe_clip_value: float = 10.0,
+        # Phase 8-Gamma G1: HMM regime gate (pre-computed track, bypasses buggy adjust_for_regime)
+        regime_track: Optional[np.ndarray] = None,
+        regime_gate_enabled: bool = False,
+        regime_gate_mode: str = "close",
+        regime_gate_bear_threshold: float = 0.5,
     ):
         """Initialize environment
 
@@ -189,6 +194,19 @@ class SingleAssetRLTradingEnv(gym.Env):
             raise ValueError(f"sharpe_clip_value must be > 0, got {sharpe_clip_value}")
         self.inactivity_penalty = inactivity_penalty
         self.sharpe_clip_value = sharpe_clip_value
+
+        # Phase 8-Gamma G1: HMM regime gate
+        if regime_gate_mode not in ("close", "refuse_entry"):
+            raise ValueError(f"regime_gate_mode must be 'close' or 'refuse_entry', got '{regime_gate_mode}'")
+        if not (0.0 <= regime_gate_bear_threshold <= 1.0):
+            raise ValueError(f"regime_gate_bear_threshold must be in [0, 1], got {regime_gate_bear_threshold}")
+        if regime_gate_enabled and regime_track is None:
+            raise ValueError("regime_gate_enabled=True requires regime_track to be provided")
+        self.regime_track = regime_track
+        self.regime_gate_enabled = regime_gate_enabled
+        self.regime_gate_mode = regime_gate_mode
+        self.regime_gate_bear_threshold = regime_gate_bear_threshold
+        self._gate_fires: int = 0
 
         # Friction parameters
         if cost_model == "futures_maker" and apply_slippage:
@@ -332,6 +350,18 @@ class SingleAssetRLTradingEnv(gym.Env):
         """Week 30: 외부에서 HMM regime 확률을 주입한다. step()에서 position sizing에 반영."""
         self._regime_probs = regime_probs
 
+    def _bear_gate_active(self) -> bool:
+        """Phase 8-Gamma G1: returns True if bear gate should fire at current_step."""
+        if not self.regime_gate_enabled or self.regime_track is None:
+            return False
+        if self.current_step is None or self.current_step >= len(self.regime_track):
+            return False
+        probs = self.regime_track[self.current_step]
+        if self.regime_gate_bear_threshold > 0:
+            return float(probs[0]) > self.regime_gate_bear_threshold  # idx 0 = BEAR
+        # argmax mode (threshold == 0)
+        return int(probs.argmax()) == 0  # BEAR=0
+
     def reset(
         self, seed: Optional[int] = None, options: Optional[dict] = None
     ) -> Tuple[np.ndarray, Dict[str, Any]]:
@@ -370,6 +400,7 @@ class SingleAssetRLTradingEnv(gym.Env):
         self.last_slippage = 0.0
         self._entry_price = None
         self._steps_since_funding = 0
+        self._gate_fires = 0
         if self._risk_manager is not None:
             self._risk_manager.reset()
 
@@ -403,6 +434,23 @@ class SingleAssetRLTradingEnv(gym.Env):
         if current_volume <= 0 or np.isnan(current_volume) or np.isinf(current_volume):
             self.logger.warning(f"❌ EXTREME VOLUME VALUE at step {self.current_step}: volume={current_volume}")
             current_volume = 1.0
+
+        # Phase 8-Gamma G1: HMM regime gate — overrides action before raw_action is read.
+        # Bypasses the buggy RLRiskManager.adjust_for_regime (see plan §1 / §4 for why).
+        if self._bear_gate_active():
+            _raw = float(action[0])
+            if self.regime_gate_mode == "close":
+                if abs(self.current_position) > 1e-6:
+                    action = np.array(
+                        [-self.current_position / max(self.max_position_size, 1e-9)],
+                        dtype=action.dtype,
+                    )
+                elif _raw > 0:
+                    action = np.array([0.0], dtype=action.dtype)
+            elif self.regime_gate_mode == "refuse_entry":
+                if _raw > 0 and self.current_position <= 0:
+                    action = np.array([0.0], dtype=action.dtype)
+            self._gate_fires += 1
 
         # Calculate target position change
         raw_action = float(action[0])
@@ -1349,6 +1397,8 @@ class SingleAssetRLTradingEnv(gym.Env):
             "last_trade_size": self.last_trade_size,
             "last_fill_rate": self.last_fill_rate,
             "last_slippage": self.last_slippage,
+            "regime_gate_fires": self._gate_fires,
+            "regime_gate_active": self._bear_gate_active() if self.regime_gate_enabled else False,
         }
 
     def _calculate_portfolio_value(self, step: int) -> float:

--- a/run_wf.py
+++ b/run_wf.py
@@ -67,6 +67,21 @@ def main() -> None:
     df = pd.read_csv(args.data, index_col=0, parse_dates=True)
     print(f"Data: {len(df)} rows, {df.index[0]} -> {df.index[-1]}")
 
+    # Phase 8-Gamma G1: fit HMM detector on full data if regime gate is enabled.
+    # Diagnostic-stage simplification: full-data fit (leakage caveat — see plan §2 arch).
+    regime_cfg = cfg.get("env", {}).get("regime_gate", {}) or {}
+    if regime_cfg.get("enabled", False):
+        from training.signals.regime_detector import RegimeDetector
+        detector_kwargs = regime_cfg.get("detector", {}) or {}
+        detector = RegimeDetector(**detector_kwargs)
+        detector.fit(df)
+        print(
+            f"RegimeDetector fitted on full data ({len(df)} rows). "
+            f"Per-regime mean returns: "
+            f"{detector._model.means_[detector._regime_order, 0].round(6).tolist()}"
+        )
+        cfg["env"]["_fitted_detector"] = detector
+
     result = train_pipeline(config=cfg, data=df)
     print("=== RESULT ===")
     print(result)

--- a/scripts/smoke_train.py
+++ b/scripts/smoke_train.py
@@ -34,10 +34,25 @@ if args.config:
         if key in ec:
             env_kwargs[key] = ec[key]
     print(f"Config loaded from {args.config}: {env_kwargs}")
+else:
+    raw = {}
 
 df = pd.read_csv("data/BTCUSDT_1h.csv", index_col=0, parse_dates=True)
 df = df.iloc[:2000].copy()
 print(f"Data: {len(df)} rows, {df.index[0]} -> {df.index[-1]}")
+
+# Phase 8-Gamma G1: fit detector and build regime_track if gate is enabled in config
+regime_cfg = (raw.get("env", {}) or {}).get("regime_gate", {}) or {}
+if regime_cfg.get("enabled", False):
+    from training.signals.regime_detector import RegimeDetector
+    from training.env_factory import _compute_regime_track
+    det = RegimeDetector(**(regime_cfg.get("detector", {}) or {}))
+    det.fit(df)
+    print(f"RegimeDetector fitted on {len(df)} rows.")
+    env_kwargs["regime_track"] = _compute_regime_track(det, df)
+    env_kwargs["regime_gate_enabled"] = True
+    env_kwargs["regime_gate_mode"] = regime_cfg.get("mode", "close")
+    env_kwargs["regime_gate_bear_threshold"] = regime_cfg.get("bear_threshold", 0.5)
 
 env = SingleAssetRLTradingEnv(
     data=df,
@@ -55,7 +70,10 @@ print(
     f"funding_rate_per_8h={getattr(env, 'funding_rate_per_8h', 0.0)}, "
     f"sharpe_weight={getattr(env, 'sharpe_weight', 0.1)}, "
     f"inactivity_penalty={getattr(env, 'inactivity_penalty', 0.0)}, "
-    f"sharpe_clip_value={getattr(env, 'sharpe_clip_value', 10.0)}"
+    f"sharpe_clip_value={getattr(env, 'sharpe_clip_value', 10.0)}, "
+    f"regime_gate_enabled={getattr(env, 'regime_gate_enabled', False)}, "
+    f"regime_gate_mode={getattr(env, 'regime_gate_mode', 'close')}, "
+    f"regime_gate_bear_threshold={getattr(env, 'regime_gate_bear_threshold', 0.5)}"
 )
 
 agent = create_agent(
@@ -99,4 +117,6 @@ print(f"reward at -5 floor:  {(rewards <= -4.99).sum()} / {len(rewards)} steps")
 print(f"reward at +5 ceil:   {(rewards >= 4.99).sum()} / {len(rewards)} steps")
 print(f"capital min/mean:    {capitals.min():.2f} / {capitals.mean():.2f}")
 print(f"NEGATIVE capital:    {neg_capital} steps {'(BUG STILL PRESENT!)' if neg_capital else '(OK)'}")
+if getattr(env, 'regime_gate_enabled', False):
+    print(f"regime_gate_fires:   {getattr(env, '_gate_fires', 0)} (last episode)")
 print("=" * 60)

--- a/tests/test_regime_gate.py
+++ b/tests/test_regime_gate.py
@@ -1,0 +1,249 @@
+"""Phase 8-Gamma G1: HMM regime gate unit tests.
+
+Tests:
+1. regime_gate_enabled=False — byte-identical env behavior (backward compat).
+2. mode=close, all-bear track, from long position: forces position to 0.
+3. mode=refuse_entry, all-bear track, from flat: blocks new long entry.
+4. bear_threshold=0 (argmax mode): gate fires when argmax==BEAR.
+5. bear_threshold=0.7, bear_prob=0.6: gate does NOT fire.
+6. _compute_regime_track: returns (n, n_regimes) shape; first lookback rows are uniform.
+7. ValueError if regime_gate_enabled=True and regime_track is None.
+8. info["regime_gate_fires"] increments correctly per episode.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from envs.single_asset_rl_env import SingleAssetRLTradingEnv
+from training.env_factory import _compute_regime_track
+from training.signals.regime_detector import RegimeDetector
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_data(n: int = 200) -> pd.DataFrame:
+    np.random.seed(42)
+    price = 100.0 + np.cumsum(np.random.randn(n) * 0.5)
+    price = np.maximum(price, 1.0)
+    return pd.DataFrame({
+        "$open": price,
+        "$high": price * 1.001,
+        "$low": price * 0.999,
+        "$close": price,
+        "$volume": np.ones(n) * 1000.0,
+    })
+
+
+def _make_bear_track(n: int, n_regimes: int = 3) -> np.ndarray:
+    """All-bear regime track: BEAR prob=1.0 at every step."""
+    track = np.zeros((n, n_regimes), dtype=np.float32)
+    track[:, 0] = 1.0  # BEAR=0 index
+    return track
+
+
+def _make_bull_track(n: int, n_regimes: int = 3) -> np.ndarray:
+    """All-bull regime track: BULL prob=1.0 at every step."""
+    track = np.zeros((n, n_regimes), dtype=np.float32)
+    track[:, 2] = 1.0  # BULL=2 index
+    return track
+
+
+def _make_env(data, regime_track=None, regime_gate_enabled=False,
+              regime_gate_mode="close", regime_gate_bear_threshold=0.5,
+              **kwargs):
+    defaults = dict(
+        initial_capital=100_000.0,
+        window_size=20,
+        partial_fills=False,  # simplify position math in tests
+        apply_slippage=False,
+    )
+    defaults.update(kwargs)
+    return SingleAssetRLTradingEnv(
+        data=data,
+        regime_track=regime_track,
+        regime_gate_enabled=regime_gate_enabled,
+        regime_gate_mode=regime_gate_mode,
+        regime_gate_bear_threshold=regime_gate_bear_threshold,
+        **defaults,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: backward compatibility — regime_gate_enabled=False is byte-identical
+# ---------------------------------------------------------------------------
+
+def test_backward_compat_gate_disabled():
+    """Gate disabled: env runs identically to pre-G1 code."""
+    data = _make_data(200)
+    env_base = _make_env(data)
+    env_gate = _make_env(data, regime_gate_enabled=False)
+
+    obs_base, _ = env_base.reset(seed=7)
+    obs_gate, _ = env_gate.reset(seed=7)
+    np.testing.assert_array_equal(obs_base, obs_gate)
+
+    # Use fixed actions from a seeded numpy array (same for both envs)
+    rng = np.random.default_rng(0)
+    for _ in range(50):
+        a = rng.uniform(-1.0, 1.0, size=(1,)).astype(np.float32)
+        ob, rb, tb, truncb, _info_b = env_base.step(a.copy())
+        og, rg, tg, truncg, _info_g = env_gate.step(a.copy())
+        np.testing.assert_array_almost_equal(ob, og, decimal=7)
+        assert abs(rb - rg) < 1e-9, f"reward mismatch: {rb} vs {rg}"
+        assert env_base.current_position == pytest.approx(env_gate.current_position, abs=1e-9)
+        if tb or truncb:
+            env_base.reset(seed=7)
+            env_gate.reset(seed=7)
+            break
+
+
+# ---------------------------------------------------------------------------
+# Test 2: mode=close, all-bear track, long position → position goes to 0
+# ---------------------------------------------------------------------------
+
+def test_mode_close_forces_flat_from_long():
+    data = _make_data(200)
+    bear_track = _make_bear_track(len(data))
+    env = _make_env(data, regime_track=bear_track, regime_gate_enabled=True,
+                    regime_gate_mode="close")
+
+    env.reset(seed=0)
+    # Manually set a long position (bypass the gate bootstrap by directly writing state)
+    env.current_position = 0.8
+
+    # One step with any action — gate should force close
+    action = np.array([1.0], dtype=np.float32)  # agent wants to go more long
+    env.step(action)
+
+    # Gate forces action = [-0.8 / 1.0] → position should reach 0
+    assert abs(env.current_position) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# Test 3: mode=refuse_entry, all-bear track, flat → blocks new long
+# ---------------------------------------------------------------------------
+
+def test_mode_refuse_entry_blocks_new_long_from_flat():
+    data = _make_data(200)
+    bear_track = _make_bear_track(len(data))
+    env = _make_env(data, regime_track=bear_track, regime_gate_enabled=True,
+                    regime_gate_mode="refuse_entry")
+
+    env.reset(seed=0)
+    assert abs(env.current_position) < 1e-9  # starts flat
+
+    action = np.array([1.0], dtype=np.float32)  # strong long signal
+    env.step(action)
+
+    # Gate intercepts: action zeroed → position stays 0
+    assert abs(env.current_position) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# Test 4: bear_threshold=0 (argmax mode) — fires when argmax==BEAR even at 0.4
+# ---------------------------------------------------------------------------
+
+def test_argmax_mode_fires_at_low_bear_prob():
+    data = _make_data(200)
+    n = len(data)
+    # Bear prob=0.4 (majority but below default 0.5 threshold)
+    track = np.array([[0.4, 0.3, 0.3]] * n, dtype=np.float32)
+    env = _make_env(data, regime_track=track, regime_gate_enabled=True,
+                    regime_gate_mode="refuse_entry",
+                    regime_gate_bear_threshold=0.0)  # argmax mode
+
+    env.reset(seed=0)
+    env.step(np.array([1.0], dtype=np.float32))
+
+    # argmax([0.4,0.3,0.3]) == 0 (BEAR) → gate fires → position stays 0
+    assert abs(env.current_position) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# Test 5: bear_threshold=0.7, bear_prob=0.6 → gate does NOT fire
+# ---------------------------------------------------------------------------
+
+def test_threshold_not_triggered_below_threshold():
+    data = _make_data(200)
+    n = len(data)
+    track = np.array([[0.6, 0.2, 0.2]] * n, dtype=np.float32)
+    env = _make_env(data, regime_track=track, regime_gate_enabled=True,
+                    regime_gate_mode="refuse_entry",
+                    regime_gate_bear_threshold=0.7)
+
+    env.reset(seed=0)
+    env.step(np.array([1.0], dtype=np.float32))
+
+    # 0.6 < 0.7 → gate does NOT fire → position changes (will be > 0 after long action)
+    assert env.current_position > 1e-5
+
+
+# ---------------------------------------------------------------------------
+# Test 6: _compute_regime_track shape + uniform priors for first lookback rows
+# ---------------------------------------------------------------------------
+
+def test_compute_regime_track_unfitted_returns_uniform():
+    data = _make_data(200)
+    detector = RegimeDetector(n_regimes=3, lookback=60)
+    # Not fitted — should return all uniform
+    track = _compute_regime_track(detector, data)
+    assert track.shape == (200, 3)
+    np.testing.assert_allclose(track, 1.0 / 3, atol=1e-6)
+
+
+def test_compute_regime_track_fitted_uniform_for_lookback_rows():
+    data = _make_data(200)
+    detector = RegimeDetector(n_regimes=3, lookback=30, n_iter=10, random_state=0)
+    detector.fit(data)
+    track = _compute_regime_track(detector, data)
+    assert track.shape == (200, 3)
+    # First lookback rows must be uniform
+    uniform = 1.0 / 3
+    np.testing.assert_allclose(track[:30], uniform, atol=1e-6,
+                                err_msg="Rows before lookback should be uniform priors")
+    # At least some rows after lookback should differ from uniform (HMM has non-trivial state)
+    assert not np.allclose(track[30:], uniform, atol=1e-3), \
+        "Expected at least some non-uniform posteriors after lookback"
+
+
+# ---------------------------------------------------------------------------
+# Test 7: ValueError if regime_gate_enabled=True and regime_track is None
+# ---------------------------------------------------------------------------
+
+def test_raises_if_gate_enabled_without_track():
+    data = _make_data(200)
+    with pytest.raises(ValueError, match="regime_gate_enabled"):
+        _make_env(data, regime_track=None, regime_gate_enabled=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 8: info["regime_gate_fires"] increments correctly per episode
+# ---------------------------------------------------------------------------
+
+def test_gate_fires_counter_increments():
+    data = _make_data(200)
+    bear_track = _make_bear_track(len(data))
+    env = _make_env(data, regime_track=bear_track, regime_gate_enabled=True,
+                    regime_gate_mode="refuse_entry")
+
+    obs, info = env.reset(seed=0)
+    assert info["regime_gate_fires"] == 0
+
+    fires_before = 0
+    for _ in range(10):
+        action = np.array([1.0], dtype=np.float32)  # always tries to go long
+        _, _, term, trunc, info = env.step(action)
+        assert info["regime_gate_fires"] >= fires_before
+        fires_before = info["regime_gate_fires"]
+        if term or trunc:
+            break
+
+    # After 10 long-action steps in all-bear regime, gate must have fired
+    assert info["regime_gate_fires"] > 0
+
+    # After reset, counter resets to 0
+    _, info = env.reset(seed=0)
+    assert info["regime_gate_fires"] == 0

--- a/training/env_factory.py
+++ b/training/env_factory.py
@@ -313,6 +313,25 @@ def normalize_data_format(data: Any) -> pd.DataFrame:
 
     raise ValueError("Unsupported data format. Expected DataFrame or list of dicts.")
 
+
+def _compute_regime_track(detector, data: pd.DataFrame) -> np.ndarray:
+    """Compute per-step regime posterior probabilities along a data series.
+
+    Returns (len(data), n_regimes) array. The first `lookback` rows fall
+    back to uniform priors since the HMM needs that many samples.
+    """
+    n = len(data)
+    nr = detector.n_regimes
+    track = np.full((n, nr), 1.0 / nr, dtype=np.float32)
+    if not detector.is_fitted:
+        return track
+    lookback = detector.lookback
+    for i in range(lookback, n):
+        window = data.iloc[i - lookback: i + 1]
+        track[i] = detector.predict_proba(window)
+    return track
+
+
 def create_env(
     config: Dict[str, Any],
     data: Optional[Union[pd.DataFrame, List[Dict]]] = None,
@@ -375,6 +394,25 @@ def create_env(
 
     # Create environment based on type
     if env_type == "single_asset_rl":
+        # Phase 8-Gamma G1: build regime_track if gate is enabled
+        regime_gate_cfg = env_config.get("regime_gate", {}) or {}
+        regime_track = None
+        if regime_gate_cfg.get("enabled", False):
+            detector = env_config.get("_fitted_detector")
+            if detector is None:
+                raise ValueError(
+                    "regime_gate.enabled=true but no fitted detector in "
+                    "env_config['_fitted_detector']. Fit the detector in "
+                    "run_wf.py before calling env_factory."
+                )
+            regime_track = _compute_regime_track(detector, data)
+            logger.info(
+                "Regime track computed: %d steps, mean bear prob %.3f, mean bull prob %.3f",
+                len(regime_track),
+                float(regime_track[:, 0].mean()),
+                float(regime_track[:, 2].mean()),
+            )
+
         # Create single-asset environment with only supported parameters
         env = SingleAssetRLTradingEnv(
             data=data,
@@ -396,6 +434,11 @@ def create_env(
             funding_rate_per_8h=env_config.get("funding_rate_per_8h", 0.0001),
             inactivity_penalty=env_config.get("inactivity_penalty", 0.0),
             sharpe_clip_value=env_config.get("sharpe_clip_value", 10.0),
+            # Phase 8-Gamma G1: regime gate pass-through
+            regime_track=regime_track,
+            regime_gate_enabled=regime_gate_cfg.get("enabled", False),
+            regime_gate_mode=regime_gate_cfg.get("mode", "close"),
+            regime_gate_bear_threshold=regime_gate_cfg.get("bear_threshold", 0.5),
         )
 
         logger.info(f"Created single-agent environment: {env}")


### PR DESCRIPTION
## Summary

Phase 8-Gamma G1 Step 2: wire the existing HMM regime detector into the RL env as a hard bear-regime gate. This is the diagnostic implementation (full-data fit, hard gate) as specified in `/Users/skylar/.claude/plans/phase8-gamma-regime-gate.md`.

### Audit summary (§1)

| Component | Status |
|---|---|
| `training/signals/regime_detector.py` | ✅ Production-quality, outputs `[bear, sideways, bull]` probs |
| `set_regime_probs()` hook | ⚠️ Exists but was never called (dangling) |
| `RLRiskManager.adjust_for_regime` | 🐛 Semantically broken (treats bull_prob as high_vol_prob) — **left as-is per §4** |
| `env_factory → env` risk_manager pass-through | ❌ Missing — gate path was entirely dead |
| Caller for regime data | ❌ Missing — added in this PR |

### Intentional diagnostic-stage simplifications (§2 arch)

1. **HMM fitted on FULL data once** — leakage caveat, diagnostic question is "does the gate concept work at all"
2. **Hard gate** via argmax or `bear_threshold` — cleaner empirical signal than soft scaling
3. **Gate in `env.step()` directly** — bypasses buggy `RLRiskManager.adjust_for_regime`

### Files changed

| File | Change |
|---|---|
| `envs/single_asset_rl_env.py` | `regime_track` param, `_bear_gate_active()`, gate logic before `raw_action`, info dict, `_gate_fires` reset |
| `training/env_factory.py` | `_compute_regime_track()` helper, pass-through to env |
| `run_wf.py` | Detector fit + `cfg["env"]["_fitted_detector"]` injection |
| `config/phase8_gamma/G1_regime_gate.yaml` | New diagnostic config (futures_maker baseline + regime_gate) |
| `config/schema.py` | 3 validators: `regime_gate_mode`, `regime_gate_bear_threshold` |
| `tests/test_regime_gate.py` | **9 tests** — backward compat, close mode, refuse_entry mode, argmax mode, threshold boundary, `_compute_regime_track`, ValueError guard, `gate_fires` counter |
| `scripts/smoke_train.py` | Regime gate handling + print line |

## Smoke results (§5 pre-PR checklist)

1. ✅ `python scripts/smoke_train.py --config config/phase8_gamma/G1_regime_gate.yaml` → "RegimeDetector fitted", `regime_gate_fires=3 (last episode)`
2. ✅ `pytest tests/test_regime_gate.py -v` → **9/9 passed**
3. ✅ `pytest tests/test_aggregate_wf_results.py tests/test_train_pipeline_random_start.py tests/test_reward_shaping.py` → **52/52 passed**
4. ✅ `python run_wf.py --config config/phase8_gamma/G1_regime_gate.yaml --n_splits 2 --total_timesteps 5000` → "RegimeDetector fitted" + `=== RESULT ===` emitted normally

## Backward compatibility

`regime_gate_enabled=False` (default) → env behavior is **byte-identical** to pre-G1. Verified by `test_backward_compat_gate_disabled` (Test 1).

## Next step (Step 3)

Operator launches 50k diagnostic on trading-pc after this PR merges:

```powershell
$env:PYTHONIOENCODING = "utf-8"
git checkout main; git pull
mkdir -p logs\phase8_gamma
Start-Process powershell -ArgumentList "-NoProfile -Command python run_wf.py --config config/phase8_gamma/G1_regime_gate.yaml --n_splits 12 --total_timesteps 50000 *> logs\phase8_gamma\G1_regime_gate_50k.log" -WindowStyle Hidden
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)