### PR TITLE
feat(phase8-gamma): G1 diagnostics polish — gate metrics visibility + backward-compat

### DIFF
--- a/run_wf.py
+++ b/run_wf.py
@@ -7,7 +7,13 @@ total_timesteps=1_000_000, which silently nullified the futures_maker
 override during the Phase 8-Alpha 1M re-train and the funding ablation.
 """
 import argparse
+import logging
 import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
 
 sys.path.insert(0, ".")
 
@@ -80,6 +86,17 @@ def main() -> None:
             f"Per-regime mean returns: "
             f"{detector._model.means_[detector._regime_order, 0].round(6).tolist()}"
         )
+        # Phase 8-Gamma G1 diagnostic: pre-compute regime distribution
+        from training.env_factory import _compute_regime_track
+        full_track = _compute_regime_track(detector, df)
+        post = full_track[detector.lookback:]
+        am = post.argmax(axis=1)
+        print(f"Regime distribution (post-lookback, {len(post)} bars):")
+        print(f"  argmax==BEAR: {(am==0).sum()} ({100*(am==0).mean():.1f}%)")
+        print(f"  argmax==SIDE: {(am==1).sum()} ({100*(am==1).mean():.1f}%)")
+        print(f"  argmax==BULL: {(am==2).sum()} ({100*(am==2).mean():.1f}%)")
+        print(f"  bear_prob > 0.5: {(post[:,0] > 0.5).mean():.3f}")
+        print(f"  bear_prob > 0.7: {(post[:,0] > 0.7).mean():.3f}")
         cfg["env"]["_fitted_detector"] = detector
 
     result = train_pipeline(config=cfg, data=df)

--- a/scripts/aggregate_wf_results.py
+++ b/scripts/aggregate_wf_results.py
@@ -44,6 +44,9 @@ class ParsedFold:
     oos_total_return_random: float
     oos_trade_count_mean: float
     oos_trade_count_random_mean: float
+    # Phase 8-Gamma G1 diagnostic — NaN when absent from older logs
+    oos_mean_gate_fires_per_episode: float = float("nan")
+    oos_mean_gate_active_fraction: float = float("nan")
 
 
 @dataclass
@@ -76,6 +79,14 @@ class VariantResult:
         vals = self._fold_values("oos_trade_count_random_mean")
         return float(sum(vals) / len(vals)) if vals else float("nan")
 
+    def gate_fires_per_ep_mean(self) -> float:
+        vals = self._fold_values("oos_mean_gate_fires_per_episode")
+        return float(sum(vals) / len(vals)) if vals else float("nan")
+
+    def gate_active_fraction_mean(self) -> float:
+        vals = self._fold_values("oos_mean_gate_active_fraction")
+        return float(sum(vals) / len(vals)) if vals else float("nan")
+
     def n_folds(self) -> int:
         return len(self.folds)
 
@@ -102,6 +113,9 @@ _FOLD_RE = re.compile(
     r"oos_total_return_random=(?P<oos_total_return_random>" + _FLOAT + r"),\s*"
     r"oos_trade_count_mean=(?P<oos_trade_count_mean>" + _FLOAT + r"),\s*"
     r"oos_trade_count_random_mean=(?P<oos_trade_count_random_mean>" + _FLOAT + r"),\s*"
+    # Optional Phase 8-Gamma G1 fields — present in newer logs, absent in older
+    r"(?:oos_mean_gate_fires_per_episode=(?P<gate_fires>" + _FLOAT + r"),\s*"
+    r"oos_mean_gate_active_fraction=(?P<gate_frac>" + _FLOAT + r"),\s*)?"
     r"metrics=\{[^}]*\}"
     r"\)"
 )
@@ -155,6 +169,8 @@ def parse_log(path: Path) -> List[ParsedFold]:
 
     for m in _FOLD_RE.finditer(result_text):
         g = m.groupdict()
+        gate_fires = _parse_float(g["gate_fires"]) if g.get("gate_fires") is not None else float("nan")
+        gate_frac = _parse_float(g["gate_frac"]) if g.get("gate_frac") is not None else float("nan")
         folds.append(ParsedFold(
             fold_idx=int(g["fold_idx"]),
             is_sharpe=_parse_float(g["is_sharpe"]),
@@ -165,6 +181,8 @@ def parse_log(path: Path) -> List[ParsedFold]:
             oos_total_return_random=_parse_float(g["oos_total_return_random"]),
             oos_trade_count_mean=_parse_float(g["oos_trade_count_mean"]),
             oos_trade_count_random_mean=_parse_float(g["oos_trade_count_random_mean"]),
+            oos_mean_gate_fires_per_episode=gate_fires,
+            oos_mean_gate_active_fraction=gate_frac,
         ))
 
     if not folds:
@@ -246,6 +264,12 @@ def _f2(v: float) -> str:
     return f"{v:.2f}"
 
 
+def _gate_fmt(v: float) -> str:
+    if math.isnan(v):
+        return "n/a"
+    return f"{v:.2f}"
+
+
 def print_table(
     variants: List[VariantResult],
     bull_indices: List[int],
@@ -253,7 +277,8 @@ def print_table(
 ) -> None:
     header = (
         f"{'Variant':<12} {'All mean(rnd)':>14} {'Bull mean':>10} "
-        f"{'Bear mean':>10} {'Folds+':>7} {'Trades/ep':>10}"
+        f"{'Bear mean':>10} {'Folds+':>7} {'Trades/ep':>10} "
+        f"{'GateFires/ep':>13} {'GateActiveFrac':>15}"
     )
     sep = "-" * len(header)
     print(sep)
@@ -266,9 +291,32 @@ def print_table(
             f"{_pct(v.bull_mean_random(bull_indices)):>10} "
             f"{_pct(v.bear_mean_random(bear_indices)):>10} "
             f"{v.folds_positive():>5}/{v.n_folds():<2} "
-            f"{_f2(v.trades_per_ep()):>10}"
+            f"{_f2(v.trades_per_ep()):>10} "
+            f"{_gate_fmt(v.gate_fires_per_ep_mean()):>13} "
+            f"{_gate_fmt(v.gate_active_fraction_mean()):>15}"
         )
     print(sep)
+    # Warn if a G1/gamma variant has dormant gate
+    for v in variants:
+        name_lower = v.name.lower()
+        if "g1" in name_lower or "gamma" in name_lower or "regime" in name_lower:
+            gf = v.gate_fires_per_ep_mean()
+            if math.isnan(gf):
+                print(
+                    f"WARNING: variant '{v.name}' has no gate metrics. "
+                    "Run with logger.INFO + diagnostic-polish PR.",
+                    file=sys.stderr,
+                )
+            elif gf < 1.0:
+                print(
+                    f"WARNING: variant '{v.name}' shows mean gate_fires/ep = {gf:.2f} < 1.",
+                    file=sys.stderr,
+                )
+                print(
+                    "  → Detector dormant or evaluator not capturing info. "
+                    "Check run_wf log for 'argmax==BEAR' counts.",
+                    file=sys.stderr,
+                )
 
 
 def print_fold_detail(variant: VariantResult) -> None:

--- a/tests/test_aggregate_wf_results.py
+++ b/tests/test_aggregate_wf_results.py
@@ -24,6 +24,7 @@ from aggregate_wf_results import (
     main,
     parse_log,
     _parse_fold_range,
+    _FOLD_RE,
 )
 
 
@@ -431,3 +432,42 @@ class TestCLI:
         assert rc == 0
         out = capsys.readouterr().out
         assert "Per-fold detail" in out
+
+
+# ---------------------------------------------------------------------------
+# Phase 8-Gamma G1: gate metric fields + backward-compat
+# ---------------------------------------------------------------------------
+
+class TestGateMetricFields:
+    def test_parse_fold_with_gate_fields(self):
+        """Parser correctly captures new gate metric fields."""
+        text = (
+            "FoldResult(fold_idx=0, train_size=100, test_size=20, "
+            "is_sharpe=0.5, oos_sharpe=0.3, oos_max_drawdown=0.05, "
+            "oos_total_return=0.01, oos_sharpe_random=0.2, "
+            "oos_total_return_random=0.005, oos_trade_count_mean=2.0, "
+            "oos_trade_count_random_mean=2.5, "
+            "oos_mean_gate_fires_per_episode=12.3, "
+            "oos_mean_gate_active_fraction=0.15, "
+            "metrics={})"
+        )
+        matches = list(_FOLD_RE.finditer(text))
+        assert len(matches) == 1
+        g = matches[0].groupdict()
+        assert abs(float(g["gate_fires"]) - 12.3) < 1e-9
+        assert abs(float(g["gate_frac"]) - 0.15) < 1e-9
+
+    def test_parse_fold_without_gate_fields_backward_compat(self):
+        """Old logs without gate fields still parse (backward-compat)."""
+        text = (
+            "FoldResult(fold_idx=0, train_size=100, test_size=20, "
+            "is_sharpe=0.5, oos_sharpe=0.3, oos_max_drawdown=0.05, "
+            "oos_total_return=0.01, oos_sharpe_random=0.2, "
+            "oos_total_return_random=0.005, oos_trade_count_mean=2.0, "
+            "oos_trade_count_random_mean=2.5, metrics={})"
+        )
+        matches = list(_FOLD_RE.finditer(text))
+        assert len(matches) == 1
+        g = matches[0].groupdict()
+        assert g.get("gate_fires") is None
+        assert g.get("gate_frac") is None

--- a/tests/test_regime_gate.py
+++ b/tests/test_regime_gate.py
@@ -247,3 +247,32 @@ def test_gate_fires_counter_increments():
     # After reset, counter resets to 0
     _, info = env.reset(seed=0)
     assert info["regime_gate_fires"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 9: gate_fires cumulative count persists to final info dict
+# ---------------------------------------------------------------------------
+
+def test_gate_fires_persists_across_episode_to_info():
+    """Confirms that final info dict captures cumulative gate_fires for the episode.
+
+    Regression: protects against future refactor that resets gate_fires before _get_info.
+    """
+    data = _make_data(200)
+    bear_track = _make_bear_track(len(data))
+    env = _make_env(data, regime_track=bear_track, regime_gate_enabled=True,
+                    regime_gate_mode="refuse_entry")
+    env.reset(seed=0)
+    last_info = {}
+    for _ in range(20):
+        action = np.array([1.0], dtype=np.float32)
+        _, _, term, trunc, info = env.step(action)
+        last_info = info
+        if term or trunc:
+            break
+    assert last_info["regime_gate_fires"] > 0, (
+        f"Expected non-zero fires after 20 long-actions in all-bear regime, "
+        f"got {last_info['regime_gate_fires']}"
+    )
+    assert last_info["regime_gate_fires"] == env._gate_fires, \
+        "info dict should mirror env._gate_fires"

--- a/training/env_factory.py
+++ b/training/env_factory.py
@@ -406,11 +406,16 @@ def create_env(
                     "run_wf.py before calling env_factory."
                 )
             regime_track = _compute_regime_track(detector, data)
+            am = regime_track[detector.lookback:].argmax(axis=1)
             logger.info(
-                "Regime track computed: %d steps, mean bear prob %.3f, mean bull prob %.3f",
+                "Regime track computed: %d steps, mean bear %.3f, mean bull %.3f, "
+                "argmax BEAR=%d (%.1f%%) SIDE=%d (%.1f%%) BULL=%d (%.1f%%)",
                 len(regime_track),
                 float(regime_track[:, 0].mean()),
                 float(regime_track[:, 2].mean()),
+                int((am == 0).sum()), 100 * (am == 0).mean(),
+                int((am == 1).sum()), 100 * (am == 1).mean(),
+                int((am == 2).sum()), 100 * (am == 2).mean(),
             )
 
         # Create single-asset environment with only supported parameters

--- a/training/validation/walk_forward.py
+++ b/training/validation/walk_forward.py
@@ -41,6 +41,9 @@ class FoldResult:
     oos_total_return_random: float = 0.0
     oos_trade_count_mean: float = 0.0
     oos_trade_count_random_mean: float = 0.0
+    # Phase 8-Gamma G1 diagnostic: gate activity (random-start eval only)
+    oos_mean_gate_fires_per_episode: float = 0.0
+    oos_mean_gate_active_fraction: float = 0.0
     metrics: Dict[str, float] = field(default_factory=dict)
 
 
@@ -84,6 +87,14 @@ class WalkForwardResult:
     def oos_total_return_random_mean(self) -> float:
         return float(np.mean([f.oos_total_return_random for f in self.folds])) if self.folds else 0.0
 
+    @property
+    def oos_mean_gate_fires_per_episode(self) -> float:
+        return float(np.mean([f.oos_mean_gate_fires_per_episode for f in self.folds])) if self.folds else 0.0
+
+    @property
+    def oos_mean_gate_active_fraction(self) -> float:
+        return float(np.mean([f.oos_mean_gate_active_fraction for f in self.folds])) if self.folds else 0.0
+
     def summary(self) -> Dict[str, float]:
         return {
             "oos_sharpe_mean": self.oos_sharpe,
@@ -94,6 +105,8 @@ class WalkForwardResult:
             "n_folds": len(self.folds),
             "oos_total_return_mean": self.oos_total_return_mean,
             "oos_total_return_random_mean": self.oos_total_return_random_mean,
+            "oos_mean_gate_fires_per_episode": self.oos_mean_gate_fires_per_episode,
+            "oos_mean_gate_active_fraction": self.oos_mean_gate_active_fraction,
         }
 
 
@@ -229,7 +242,9 @@ class WalkForwardValidator:
 
             # Test (out-of-sample) — fixed start
             test_env = env_factory(test_df)
-            oos_returns, oos_trades = self._evaluate(agent, test_env, eval_episodes, random_start=False)
+            oos_returns, oos_trades, _gate_fires_fixed, _step_counts_fixed = self._evaluate(
+                agent, test_env, eval_episodes, random_start=False
+            )
             oos_sharpe = self._compute_sharpe(oos_returns)
             oos_dd = self._max_drawdown(oos_returns)
             oos_total = float(np.mean(oos_returns)) if len(oos_returns) > 0 else 0.0
@@ -239,13 +254,19 @@ class WalkForwardValidator:
             oos_sharpe_random = 0.0
             oos_total_random = 0.0
             oos_trade_count_random_mean = 0.0
+            oos_mean_gate_fires_per_episode = 0.0
+            oos_mean_gate_active_fraction = 0.0
             if random_start_eval:
-                oos_returns_random, oos_trades_random = self._evaluate(
-                    agent, test_env, eval_episodes, random_start=True
-                )
+                oos_returns_random, oos_trades_random, oos_gate_fires_random, oos_step_counts_random = \
+                    self._evaluate(agent, test_env, eval_episodes, random_start=True)
                 oos_sharpe_random = self._compute_sharpe(oos_returns_random)
                 oos_total_random = float(np.mean(oos_returns_random)) if len(oos_returns_random) > 0 else 0.0
                 oos_trade_count_random_mean = float(np.mean(oos_trades_random)) if len(oos_trades_random) > 0 else 0.0
+                oos_mean_gate_fires_per_episode = float(np.mean(oos_gate_fires_random)) if len(oos_gate_fires_random) > 0 else 0.0
+                total_steps = int(np.sum(oos_step_counts_random))
+                oos_mean_gate_active_fraction = (
+                    float(np.sum(oos_gate_fires_random)) / total_steps if total_steps > 0 else 0.0
+                )
 
             fold = FoldResult(
                 fold_idx=i,
@@ -260,13 +281,18 @@ class WalkForwardValidator:
                 oos_total_return_random=oos_total_random,
                 oos_trade_count_mean=oos_trade_count_mean,
                 oos_trade_count_random_mean=oos_trade_count_random_mean,
+                oos_mean_gate_fires_per_episode=oos_mean_gate_fires_per_episode,
+                oos_mean_gate_active_fraction=oos_mean_gate_active_fraction,
             )
             folds.append(fold)
 
             _rand_suffix = (f" | random-start OOS return={oos_total_random:.4f}") if random_start_eval else ""
             logger.info(
-                "Fold %d result — IS Sharpe=%.3f, OOS Sharpe=%.3f, OOS DD=%.3f%s",
-                i + 1, is_sharpe, oos_sharpe, oos_dd, _rand_suffix,
+                "Fold %d result — IS Sharpe=%.3f, OOS Sharpe=%.3f, OOS DD=%.3f, "
+                "gate_fires/ep=%.1f, gate_active_frac=%.3f%s",
+                i + 1, is_sharpe, oos_sharpe, oos_dd,
+                oos_mean_gate_fires_per_episode, oos_mean_gate_active_fraction,
+                _rand_suffix,
             )
 
             if is_sharpe > 0 and oos_sharpe > 0:
@@ -325,7 +351,7 @@ class WalkForwardValidator:
                 pass
             agent.learn(total_timesteps=total_timesteps, progress_bar=False)
             # After training, roll out a few episodes to score IS Sharpe.
-            is_returns, _ = WalkForwardValidator._evaluate(agent, env, max(1, eval_episodes))
+            is_returns, _, _, _ = WalkForwardValidator._evaluate(agent, env, max(1, eval_episodes))
             return is_returns
 
         # Legacy custom-wrapper path: collect per-episode portfolio % returns
@@ -378,8 +404,11 @@ class WalkForwardValidator:
     @staticmethod
     def _evaluate(
         agent, env, n_episodes: int, random_start: bool = False
-    ) -> Tuple[np.ndarray, np.ndarray]:
-        """Evaluate agent without training. Returns (per-episode % returns, per-episode trade counts).
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Evaluate agent without training.
+
+        Returns (per-episode % returns, per-episode trade counts,
+                 per-episode gate_fires, per-episode step counts).
 
         Returns per-episode % returns based on portfolio value, NOT raw reward sums
         (which are scaled and clipped and so do not have %-return semantics).
@@ -396,18 +425,29 @@ class WalkForwardValidator:
         reset_options = {"random_start": True} if random_start else None
         returns = []
         trade_counts = []
+        gate_fires_list = []
+        step_counts = []
         for _ in range(n_episodes):
             obs, _ = env.reset(options=reset_options)
             done = False
             last_info: Dict[str, Any] = {}
+            n_steps = 0
             while not done:
                 action = WalkForwardValidator._agent_action(agent, obs, deterministic=False)
                 obs, _reward, done, truncated, last_info = env.step(action)
+                n_steps += 1
                 if truncated:
                     break
             returns.append(WalkForwardValidator._episode_pv_return(env, last_info))
             trade_counts.append(int(last_info.get("trade_count", getattr(env, "trade_count", 0))))
-        return np.array(returns, dtype=np.float64), np.array(trade_counts, dtype=np.int64)
+            gate_fires_list.append(int(last_info.get("regime_gate_fires", 0)))
+            step_counts.append(n_steps)
+        return (
+            np.array(returns, dtype=np.float64),
+            np.array(trade_counts, dtype=np.int64),
+            np.array(gate_fires_list, dtype=np.int64),
+            np.array(step_counts, dtype=np.int64),
+        )
 
     @staticmethod
     def _compute_sharpe(returns: np.ndarray, risk_free: float = 0.0) -> float:


### PR DESCRIPTION
## §0 Mac Diagnostic Summary

Before this PR, the G1 50k run (PR #140) was **INCONCLUSIVE** (G1 vs B0 diff = 0.01pp) because:
- Trading-pc logs had **0 logger.INFO messages** (no `logging.basicConfig` in run_wf.py)
- `regime_gate_fires` was not surfaced to the aggregator
- No direct evidence that the gate actually fired during OOS eval

Mac-side diagnostic confirmed (full 17520-row data, RegimeDetector lookback=60):
- `argmax==BEAR: 7.8%` / `SIDEWAYS: 50.8%` / `BULL: 41.4%`
- `bear_prob > 0.5: 7.7%` — effectively binary detector
- Per-fold gate fires vary: fold 9 = 29.5 fires/ep (16% bear), fold 4 = 1.5/ep
- 50k inconclusive = **scenario (A): policy underdev** (trade/ep 1.48 — gate effect masked)

**Hypothesis**: G1 gate was wiring correctly but not visible in logs. This PR fills the evidence gap.

## Files Modified (6 files, ~150 LoC)

| File | Change |
|------|--------|
| `run_wf.py` | `logging.basicConfig(INFO)` + regime distribution print after `detector.fit` |
| `training/validation/walk_forward.py` | `FoldResult` +2 fields; `_evaluate` 2-tuple to 4-tuple; `validate()` gate metrics; `summary()` gate means |
| `training/env_factory.py` | `logger.info` extended with argmax BEAR/SIDE/BULL counts |
| `scripts/aggregate_wf_results.py` | `ParsedFold` +2 fields (NaN default); `_FOLD_RE` optional group; +2 table columns; WARNING for dormant gate |
| `tests/test_regime_gate.py` | +1 test: `gate_fires_persists_across_episode_to_info` |
| `tests/test_aggregate_wf_results.py` | +2 tests: new gate fields + backward-compat (old logs parse without fail) |

**G1 core code (`envs/single_asset_rl_env.py` gate logic) is UNCHANGED.**

## Smoke Results

- ✓ `pytest tests/test_regime_gate.py` — 10/10 pass (9 original + 1 new)
- ✓ `pytest tests/test_aggregate_wf_results.py` — 41/41 pass (39 original + 2 new)
- ✓ `pytest tests/test_reward_shaping.py tests/test_train_pipeline_random_start.py` — 13/13 pass
- ✓ `smoke_train.py --config G1_regime_gate.yaml` — `regime_gate_fires: 44` visible in output
- ✓ `_evaluate` 4-tuple verified inline: `gate_fires=[0 0 0]`, `step_counts=[90 90 90]`
- ✓ Aggregator backward-compat dry run: B0 (old format) shows `GateFires/ep: n/a`; G1 (new format) shows `GateFires/ep: 9.20`
- ⚠ `smoke_walkforward.py` skipped on Mac — data file is 200 rows; smoke requires 1500 rows (trading-pc only)

## §5 Verdict Matrix — 1M Decision Branches

After 50k retry on trading-pc with this PR merged:

| Scenario | Expected pattern | Verdict | Next action |
|----------|-----------------|---------|-------------|
| **(A1) Gate active, policy underdev** | `gate_fires/ep ~9`, `trades/ep ~1.5`, G1 within 0.05pp of B0 | INCONCLUSIVE-FAVORABLE | **1M go** on trading-pc (~10h) |
| **(A2) Gate active, policy trading, marginal** | `gate_fires/ep ~9`, `trades/ep >= 3`, `|G1-B0| < 0.1pp` | INCONCLUSIVE-MARGINAL | **1M go (cautious)** |
| **(B) Gate dormant** | `gate_fires/ep < 2` across all folds | NO-GO via gate | G1 폐기, G2 (realized-PnL reward) plan |
| **(C) Gate active but G1 clearly worse** | `gate_fires/ep` nontrivial, `G1 - B0 < -0.2pp` all folds | NO-GO | G2 direct |

Most likely: scenario (A1) → 1M go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
