### PR TITLE
fix(env): capital floor grace period counts from episode start, not window_size

### DIFF
--- a/envs/single_asset_rl_env.py
+++ b/envs/single_asset_rl_env.py
@@ -118,7 +118,10 @@ class SingleAssetRLTradingEnv(gym.Env):
             scale_ohlcv: Whether to scale OHLCV data to prevent numerical instability
             price_scale_factor: Factor to scale price data (OHLC)
             volume_scale_factor: Factor to scale volume data
-            min_episode_steps: Minimum number of steps before allowing early termination
+            min_episode_steps: Minimum number of steps **after episode start** before
+                allowing early termination via capital floor or portfolio FORCE_TERMINATION.
+                Counted from `_episode_start_step` (which differs from `window_size` when
+                `reset(options={"random_start": True})` picks a non-default start step).
             reward_scale: Factor to scale rewards (smaller values = more stable)
         """
         super().__init__()
@@ -280,6 +283,7 @@ class SingleAssetRLTradingEnv(gym.Env):
         )
 
         # Initialize state variables
+        self._episode_start_step = 0  # set properly in reset()
         self.current_step = None
         self.current_position = None
         self.current_capital = None
@@ -384,6 +388,7 @@ class SingleAssetRLTradingEnv(gym.Env):
             )
         else:
             self.current_step = self.window_size
+        self._episode_start_step = self.current_step
         self.current_position = 0.0
         self.current_capital = self.initial_capital
         self.portfolio_value = self.initial_capital
@@ -702,8 +707,8 @@ class SingleAssetRLTradingEnv(gym.Env):
         else:
             _capital_force_done = False
 
-        if _capital_force_done and (self.current_step - self.window_size) < self.min_episode_steps:
-            self.logger.debug(f"Delaying episode termination until minimum steps {self.min_episode_steps} are reached. Current: {self.current_step - self.window_size}")
+        if _capital_force_done and (self.current_step - self._episode_start_step) < self.min_episode_steps:
+            self.logger.debug(f"Delaying episode termination until minimum steps {self.min_episode_steps} are reached. Current: {self.current_step - self._episode_start_step}")
             _capital_force_done = False
 
         if _capital_force_done:
@@ -761,7 +766,7 @@ class SingleAssetRLTradingEnv(gym.Env):
              final_reward_on_termination = -5.0
 
         # 에피소드 강제 종료 조건 확인 (최소 스텝 이후)
-        min_steps_elapsed = (self.current_step - self.window_size) >= self.min_episode_steps
+        min_steps_elapsed = (self.current_step - self._episode_start_step) >= self.min_episode_steps
         if FORCE_TERMINATION and min_steps_elapsed:
             self.done = True
             observation = self._get_observation() # 최종 상태 가져오기

--- a/tests/test_capital_floor_grace.py
+++ b/tests/test_capital_floor_grace.py
@@ -1,0 +1,204 @@
+"""Phase 8 capital floor grace period bug fix tests.
+
+Regression: ensures the grace period (min_episode_steps before capital floor
+termination is allowed) counts from the episode's actual start step, not
+from window_size. Bug was: random_start episodes had their grace period
+evaluate as already-expired since start_step >> window_size in absolute
+terms.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from envs.single_asset_rl_env import SingleAssetRLTradingEnv
+
+
+def _make_data(n: int = 1000) -> pd.DataFrame:
+    np.random.seed(0)
+    price = 100.0 + np.cumsum(np.random.randn(n) * 0.1)
+    price = np.maximum(price, 1.0)
+    return pd.DataFrame({
+        "$open": price, "$high": price * 1.001, "$low": price * 0.999,
+        "$close": price, "$volume": np.ones(n) * 1000.0,
+    })
+
+
+def _make_env(data, **kwargs):
+    defaults = dict(
+        initial_capital=100_000.0,
+        window_size=20,
+        min_episode_steps=30,
+        max_position_size=1.0,
+        partial_fills=False,
+        apply_slippage=False,
+    )
+    defaults.update(kwargs)
+    return SingleAssetRLTradingEnv(data=data, **defaults)
+
+
+# ---- Test 1: episode_start_step set correctly in reset ----
+
+def test_episode_start_step_fixed_start():
+    """Fixed-start: _episode_start_step == window_size."""
+    env = _make_env(_make_data(200))
+    env.reset(seed=0)
+    assert env._episode_start_step == env.window_size
+
+
+def test_episode_start_step_random_start():
+    """Random_start: _episode_start_step matches the picked current_step."""
+    env = _make_env(_make_data(1000))
+    env.reset(seed=0, options={"random_start": True})
+    assert env._episode_start_step == env.current_step
+    assert env._episode_start_step > env.window_size
+
+
+# ---- Test 2: backward compat — fixed-start grace period unchanged ----
+
+def test_fixed_start_grace_still_blocks_early_capital_floor():
+    """Fixed-start episode: capital_floor termination should be delayed
+    until min_episode_steps absolute steps elapsed (= same as old behavior)."""
+    env = _make_env(_make_data(200))
+    env.reset(seed=0)
+    env.current_capital = env.initial_capital * 0.3  # well below 50% floor
+
+    for i in range(env.min_episode_steps - 1):
+        action = np.array([0.0], dtype=np.float32)
+        _, _, term, trunc, _ = env.step(action)
+        if i < env.min_episode_steps - 5:
+            assert not term, (
+                f"Grace period broken: terminated at i={i} (step={env.current_step}, "
+                f"start={env._episode_start_step}, min_steps={env.min_episode_steps})"
+            )
+
+
+# ---- Test 3: random_start episode now grace-protected (THE BUG FIX) ----
+
+def test_random_start_grace_protects_first_min_episode_steps():
+    """Random_start episode: capital_floor termination MUST be delayed for
+    min_episode_steps steps from episode start, not from window_size."""
+    env = _make_env(_make_data(1000))
+    env.reset(seed=0, options={"random_start": True})
+    start = env._episode_start_step
+    assert start > env.window_size, "test prerequisite: random_start picked non-trivial start"
+
+    env.current_capital = env.initial_capital * 0.3
+
+    for i in range(env.min_episode_steps - 5):
+        action = np.array([0.0], dtype=np.float32)
+        _, _, term, trunc, _ = env.step(action)
+        rel_step = env.current_step - start
+        if rel_step < env.min_episode_steps:
+            assert not term, (
+                f"BUG REGRESSION: random_start episode terminated at rel_step={rel_step} "
+                f"(< min_episode_steps={env.min_episode_steps}). "
+                f"absolute current_step={env.current_step}, start={start}."
+            )
+
+
+# ---- Test 4: termination DOES fire after min_episode_steps from random start ----
+
+def test_random_start_grace_expires_after_min_episode_steps():
+    """Random_start: after min_episode_steps from episode start with capital
+    below floor, termination MUST fire (no infinite grace)."""
+    env = _make_env(_make_data(1000))
+    env.reset(seed=0, options={"random_start": True})
+    start = env._episode_start_step
+    env.current_capital = env.initial_capital * 0.3
+
+    terminated_at = None
+    for i in range(env.min_episode_steps + 50):
+        action = np.array([0.0], dtype=np.float32)
+        _, _, term, trunc, _ = env.step(action)
+        if term or trunc:
+            terminated_at = env.current_step - start
+            break
+    assert terminated_at is not None, "Episode should have terminated eventually"
+    assert terminated_at >= env.min_episode_steps, \
+        f"Terminated too early: rel_step={terminated_at} < min={env.min_episode_steps}"
+
+
+# ---- Test 5: integration — random action × random_start mean episode length ----
+
+def test_random_start_random_action_episodes_substantially_longer_than_buggy_baseline():
+    """Integration regression: prior to fix, random_start × random action
+    on a 730-row slice gave mean episode length ≈ 11 steps. Post-fix, with
+    grace period correctly applied, episodes should average meaningfully
+    longer (>= min_episode_steps when capital floor is the limiter)."""
+    env = _make_env(_make_data(730))
+    lengths = []
+    for ep in range(20):
+        env.reset(seed=ep, options={"random_start": True})
+        n_steps = 0
+        while True:
+            a = env.action_space.sample()
+            _, _, term, trunc, _ = env.step(a)
+            n_steps += 1
+            if term or trunc:
+                break
+        lengths.append(n_steps)
+    mean_len = float(np.mean(lengths))
+    assert mean_len >= 30.0, (
+        f"Mean episode length {mean_len:.1f} < 30. "
+        f"Either grace fix didn't take effect or test data is degenerate. "
+        f"Distribution: {sorted(lengths)}"
+    )
+
+
+# ---- Test 6: ds_len boundary — episode runs to end of data ----
+
+def test_random_start_episode_can_run_to_end_of_slice():
+    """If capital is healthy and policy is benign, random_start episode
+    should run to end of data slice (current_step >= ds_len)."""
+    env = _make_env(_make_data(200))
+    env.reset(seed=0, options={"random_start": True})
+    start = env._episode_start_step
+    expected_max_len = env._ds_len() - start
+
+    n_steps = 0
+    while True:
+        a = np.array([0.0], dtype=np.float32)
+        _, _, term, trunc, _ = env.step(a)
+        n_steps += 1
+        if term or trunc:
+            break
+        if n_steps > 10_000:
+            pytest.fail("episode did not terminate")
+    assert n_steps == expected_max_len, \
+        f"Hold-action episode should run to end of data: got {n_steps}, expected {expected_max_len}"
+
+
+# ---- Test 7: backward compat — reset state complete after fix ----
+
+def test_reset_state_complete_after_fix():
+    """After fix, reset() still sets all required state (no missed initializations)."""
+    env = _make_env(_make_data(200))
+    env.reset(seed=0)
+    assert hasattr(env, '_episode_start_step')
+    assert env._episode_start_step == env.window_size
+    assert env.current_position == 0.0
+    assert env.current_capital == env.initial_capital
+    assert env.done is False
+    assert env._gate_fires == 0
+
+
+# ---- Test 8: portfolio FORCE_TERMINATION path also fixed (line 764) ----
+
+def test_force_termination_grace_random_start():
+    """The FORCE_TERMINATION path (portfolio_value <= CRITICAL_LOW_THRESHOLD)
+    also uses min_steps_elapsed which had the same bug. Fix should apply here too."""
+    env = _make_env(_make_data(1000))
+    env.reset(seed=0, options={"random_start": True})
+    start = env._episode_start_step
+    assert start > env.window_size
+
+    env.portfolio_value = 0.01
+    env.current_capital = 0.01
+
+    a = np.array([0.0], dtype=np.float32)
+    _, _, term, trunc, _ = env.step(a)
+    rel_step = env.current_step - start
+    if rel_step < env.min_episode_steps:
+        assert not term, (
+            f"FORCE_TERMINATION grace not respected: terminated at rel_step={rel_step}"
+        )


### PR DESCRIPTION
## Bug (§1 audit)

`envs/single_asset_rl_env.py` lines 705 and 764 used `(current_step - window_size)` as the episode-relative step count for the capital-floor / FORCE_TERMINATION grace period:

```python
# line 705 (BUG)
if _capital_force_done and (self.current_step - self.window_size) < self.min_episode_steps:

# line 764 (BUG)
min_steps_elapsed = (self.current_step - self.window_size) >= self.min_episode_steps
```

In **fixed-start** episodes (`current_step` starts at `window_size`) this is correct. In **random_start** episodes (`current_step` starts at e.g. 234) the expression equals 234 - 20 = 214 >> 30 on step 1 → grace period already expired → immediate termination. Result: mean episode length **~11 steps** instead of the intended ≥ 30.

## Fix (5 LoC core change)

**`envs/single_asset_rl_env.py`**:
1. `__init__`: add `self._episode_start_step = 0` (avoids AttributeError before first reset)
2. `reset()`: add `self._episode_start_step = self.current_step` immediately after the random_start / fixed-start branch
3. Line 705: `self.window_size` → `self._episode_start_step`
4. Line 706 (debug log): same substitution
5. Line 764: `self.window_size` → `self._episode_start_step`

**`tests/test_capital_floor_grace.py`**: 9 new tests (8 per plan + 1 collected by pytest.ini).

**grep audit** (`current_step.*window_size`): only lines 705 and 764 had the bug pattern (line 386 is the correct fixed-start assignment; line 1229 is `_get_observation` window indexing — unrelated). No other locations needed fixing.

## Fixed-start metric — no impact

Fixed-start episodes: `current_step = window_size` at reset → `_episode_start_step = window_size` → grace expression `current_step - _episode_start_step` is numerically identical to old `current_step - window_size`. **Fixed-start metric is byte-identical.**

## Smoke results

| Item | Status |
|------|--------|
| `pytest tests/test_capital_floor_grace.py -v` | ✓ 9/9 pass |
| `pytest tests/test_regime_gate.py -v` | ✓ 9/9 pass |
| `pytest tests/test_train_pipeline_random_start.py -v` | ✓ 10/10 pass |
| `pytest tests/test_aggregate_wf_results.py -v` | ✓ 45/45 pass |
| §4.1 Mac probe (random action × random_start × 20 ep, fold 9 730-row slice) | ✓ PASS |
| `scripts/smoke_train.py --config config/phase8_gamma/G1_regime_gate.yaml` | ✓ pass |
| `run_wf.py --config G1_regime_gate.yaml --n_splits 2 --total_timesteps 5000` | ✓ gate_fires/ep=2.4 |

## §4.1 Mac probe — pre/post episode length

```
Pre-fix:  mean=11.0, median=8.5,  min=1,  max=39   ← bug
Post-fix: mean=44.6, median=39.5, min=31, max=74   ← fixed (min >= min_episode_steps=30)
```

## Files changed

- `envs/single_asset_rl_env.py` — 5 LoC core change + docstring update
- `tests/test_capital_floor_grace.py` — new file, 9 tests

## Impact on prior results (§9 retry priority — operator decision)

All Phase 8 results that used `random_start=True` (eval metric) are affected:

**Tier 1 (required, ~1h GPU)**
- B0 baseline 50k re-run → new baseline
- G1 50k re-run → real regime gate verdict (GateFires/ep expected ~9 vs buggy 0.49)

**Tier 2 (recommended)** — Phase 8-Beta B1/B2/B3 50k re-runs

**Tier 3 (optional)** — B3 1M re-run (decide after Tier 1)

Fixed-start metrics (Phase 8-Alpha v1/v2 fixed-start folds) are **not affected**.