### PR TITLE
config(phase8-gamma): G1 variants — refuse_entry + threshold 0.7

### DIFF
--- a/config/phase8_gamma/G1_refuse_entry.yaml
+++ b/config/phase8_gamma/G1_refuse_entry.yaml
@@ -1,0 +1,51 @@
+# Phase 8-Gamma G1 variant A — refuse_entry mode
+# Same as G1_regime_gate.yaml but mode=refuse_entry instead of close.
+# Hypothesis: close-mode hurts bull more than helps bear because HMM
+# false-positive bear in some bull-fold periods triggers forced close
+# (transaction cost + missed bull continuation). refuse_entry only blocks
+# NEW long entry, leaving existing long alone — should reduce bull cost.
+
+env:
+  type: single_asset_rl
+  window_size: 20
+  initial_balance: 100000.0
+  trading_fee: 0.00018
+  apply_slippage: false
+  slippage_factor: 0.0
+  cost_model: futures_maker
+  funding_rate_per_8h: 0.0001
+  max_position_size: 1.0
+  sharpe_lookback: 60
+  sharpe_weight: 0.1
+  normalize: true
+  reward_function: sharpe_ratio
+  action_type: continuous
+  include_technical_indicators: true
+  risk_adjusted: true
+  realistic_slippage: false
+
+  regime_gate:
+    enabled: true
+    mode: refuse_entry          # ← variant A
+    bear_threshold: 0.5
+    detector:
+      n_regimes: 3
+      lookback: 60
+      vol_window: 20
+      n_iter: 100
+      random_state: 42
+
+  indicators:
+    - name: RSI
+      window: 14
+    - name: MACD
+      fast_window: 12
+      slow_window: 26
+      signal_window: 9
+    - name: Bollinger
+      window: 20
+      dev: 2
+
+walk_forward:
+  random_start_eval: true
+  eval_episodes: 20

--- a/config/phase8_gamma/G1_threshold_07.yaml
+++ b/config/phase8_gamma/G1_threshold_07.yaml
@@ -1,0 +1,53 @@
+# Phase 8-Gamma G1 variant B — bear_threshold 0.7
+# Same as G1_regime_gate.yaml but bear_threshold=0.7 instead of 0.5.
+# Hypothesis: HMM bear/bull boundary is fuzzy; threshold 0.5 fires on too
+# many borderline cases (false positives in bull folds). Higher threshold
+# only fires when HMM is highly confident → fewer bull-fold disruptions
+# but still catches strong bear periods.
+# Mac diagnostic: bear_prob > 0.5 fires 7.7%, bear_prob > 0.7 fires 6.6%
+# (middle range sparse, so actual fire-rate change is small but selective).
+
+env:
+  type: single_asset_rl
+  window_size: 20
+  initial_balance: 100000.0
+  trading_fee: 0.00018
+  apply_slippage: false
+  slippage_factor: 0.0
+  cost_model: futures_maker
+  funding_rate_per_8h: 0.0001
+  max_position_size: 1.0
+  sharpe_lookback: 60
+  sharpe_weight: 0.1
+  normalize: true
+  reward_function: sharpe_ratio
+  action_type: continuous
+  include_technical_indicators: true
+  risk_adjusted: true
+  realistic_slippage: false
+
+  regime_gate:
+    enabled: true
+    mode: close
+    bear_threshold: 0.7         # ← variant B (vs 0.5 baseline)
+    detector:
+      n_regimes: 3
+      lookback: 60
+      vol_window: 20
+      n_iter: 100
+      random_state: 42
+
+  indicators:
+    - name: RSI
+      window: 14
+    - name: MACD
+      fast_window: 12
+      slow_window: 26
+      signal_window: 9
+    - name: Bollinger
+      window: 20
+      dev: 2
+
+walk_forward:
+  random_start_eval: true
+  eval_episodes: 20


### PR DESCRIPTION
## Summary
Two new YAML configs for G1 variant exploration after the PR #142 capital-floor fix revealed G1 close-mode NO-GO at 50k.

- \`config/phase8_gamma/G1_refuse_entry.yaml\` — mode=refuse_entry (only blocks new long entry, preserves held positions)
- \`config/phase8_gamma/G1_threshold_07.yaml\` — bear_threshold 0.5 → 0.7 (HMM-confident bear only)

## Context
G1_v3 (close-mode, threshold 0.5) post-fix 50k results:
- Bull: +0.34% → +0.12% (G1 worse by 0.22pp)
- Bear: -0.29% → -0.27% (G1 marginal +0.02pp)
- GateFires/ep: 1.41 (gate working correctly)

Plan §5 scenario (C): close-mode transaction cost > protection. Two variants address different aspects of this.

## Test plan
- [x] YAML schema valid (pre-commit yaml check passed)
- [ ] Operator launches \`python run_wf.py --config config/phase8_gamma/G1_refuse_entry.yaml --n_splits 12 --total_timesteps 50000\`
- [ ] Operator launches \`python run_wf.py --config config/phase8_gamma/G1_threshold_07.yaml --n_splits 12 --total_timesteps 50000\` (sequential after refuse_entry)
- [ ] Aggregator compares both vs B0_v2 baseline; verdict matrix → 1M go-or-G2