### PR TITLE
feat(env): Phase 8-Gamma G2 — realized-PnL reward (trade-frequency fix)

### DIFF
--- a/config/phase8_gamma/G2_realized_pnl.yaml
+++ b/config/phase8_gamma/G2_realized_pnl.yaml
@@ -1,0 +1,42 @@
+# Phase 8-Gamma G2 diagnostic — realized-PnL reward
+# Hypothesis: sharpe-based reward saturates → near-hold convergence at 1M
+#   (verified: B0_v2_1M trades/ep 1.46, G1_refuse_1M trades/ep 1.48 — both collapse 4×).
+# Realized PnL pays reward only on position close → zero reward on hold →
+#   policy must trade to receive reward → trade frequency preserved.
+# Diagnostic-stage simplifications:
+#   1. Pure realized PnL (no sharpe wrapping). If 50k still converges to hold,
+#      hypothesis is falsified.
+#   2. No regime gate (G1) — keep apples-to-apples vs B0_v2.
+
+env:
+  type: single_asset_rl
+  window_size: 20
+  initial_balance: 100000.0
+  trading_fee: 0.00018
+  apply_slippage: false
+  slippage_factor: 0.0
+  cost_model: futures_maker
+  funding_rate_per_8h: 0.0001
+  max_position_size: 1.0
+  sharpe_lookback: 60
+  sharpe_weight: 0.0
+  normalize: true
+  reward_function: realized_pnl
+  action_type: continuous
+  include_technical_indicators: true
+  risk_adjusted: false
+
+  indicators:
+    - name: RSI
+      window: 14
+    - name: MACD
+      fast_window: 12
+      slow_window: 26
+      signal_window: 9
+    - name: Bollinger
+      window: 20
+      dev: 2
+
+walk_forward:
+  random_start_eval: true
+  eval_episodes: 20

--- a/config/schema.py
+++ b/config/schema.py
@@ -70,6 +70,17 @@ class EnvConfig(BaseModel):
             raise ValueError(f"sharpe_clip_value must be in (0, 100], got {v}")
         return v
 
+    # Phase 8-Gamma G2: reward function selector
+    reward_function: str = "sharpe_ratio"
+
+    @field_validator("reward_function")
+    @classmethod
+    def reward_function_valid(cls, v: str) -> str:
+        valid = {"sharpe_ratio", "log_return", "realized_pnl"}
+        if v not in valid:
+            raise ValueError(f"reward_function must be one of {valid}, got '{v}'")
+        return v
+
     # Phase 8-Gamma G1: regime gate knobs (nested regime_gate dict is extra="allow")
     regime_gate_enabled: bool = False
     regime_gate_mode: str = "close"

--- a/envs/single_asset_rl_env.py
+++ b/envs/single_asset_rl_env.py
@@ -96,6 +96,8 @@ class SingleAssetRLTradingEnv(gym.Env):
         regime_gate_enabled: bool = False,
         regime_gate_mode: str = "close",
         regime_gate_bear_threshold: float = 0.5,
+        # Phase 8-Gamma G2: reward function selector
+        reward_function: str = "sharpe_ratio",
     ):
         """Initialize environment
 
@@ -210,6 +212,15 @@ class SingleAssetRLTradingEnv(gym.Env):
         self.regime_gate_mode = regime_gate_mode
         self.regime_gate_bear_threshold = regime_gate_bear_threshold
         self._gate_fires: int = 0
+
+        # Phase 8-Gamma G2: reward function selector
+        _allowed_reward_functions = {"sharpe_ratio", "log_return", "realized_pnl"}
+        if reward_function not in _allowed_reward_functions:
+            raise ValueError(
+                f"reward_function must be one of {_allowed_reward_functions}, got '{reward_function}'"
+            )
+        self.reward_function = reward_function
+        self._realized_pnl_this_step: float = 0.0
 
         # Friction parameters
         if cost_model == "futures_maker" and apply_slippage:
@@ -406,6 +417,7 @@ class SingleAssetRLTradingEnv(gym.Env):
         self._entry_price = None
         self._steps_since_funding = 0
         self._gate_fires = 0
+        self._realized_pnl_this_step = 0.0
         if self._risk_manager is not None:
             self._risk_manager.reset()
 
@@ -474,6 +486,9 @@ class SingleAssetRLTradingEnv(gym.Env):
 
         # Calculate actual position change
         actual_change = target_position - self.current_position
+
+        # Phase 8-Gamma G2: reset per-step realized PnL accumulator
+        self._realized_pnl_this_step = 0.0
 
         # DEBUG: Log action details for monitoring
         # --- START: Added Pre-Trade Logging ---
@@ -650,6 +665,16 @@ class SingleAssetRLTradingEnv(gym.Env):
             _prev_position = self.current_position
             self.current_position += actual_change
 
+            # Phase 8-Gamma G2: realized PnL on position close (computed BEFORE entry_price update)
+            if self.reward_function == "realized_pnl" and self._entry_price is not None:
+                if _prev_position > 0 and actual_change < 0:  # close / reduce long
+                    closed_size = min(_prev_position, -actual_change)
+                    self._realized_pnl_this_step = closed_size * (executed_price - self._entry_price)
+                elif _prev_position < 0 and actual_change > 0:  # close / reduce short
+                    closed_size = min(-_prev_position, actual_change)
+                    self._realized_pnl_this_step = closed_size * (self._entry_price - executed_price)
+                # else: position increase or direction-neutral — realized PnL remains 0
+
             # Week 37: update entry price for stop loss tracking
             if abs(_prev_position) < 1e-8 and abs(self.current_position) >= 1e-8:
                 self._entry_price = executed_price  # flat → non-flat: new position opened
@@ -806,6 +831,50 @@ class SingleAssetRLTradingEnv(gym.Env):
                 self.portfolio_value = self.current_capital
                 if _risk_reason == "max_drawdown":
                     self.done = True
+
+        # Phase 8-Gamma G2: realized-PnL reward path (bypasses sharpe-based reward entirely)
+        if self.reward_function == "realized_pnl":
+            realized = self._realized_pnl_this_step
+            reward_step = float(np.clip(realized / max(self.initial_capital, 1e-9), -5.0, 5.0))
+            reward_debug["basic_reward"] = reward_step
+            reward_debug["sharpe_component"] = 0.0
+            reward_debug["drawdown_penalty"] = 0.0
+            reward_debug["portfolio_change"] = 0.0
+            reward_debug["post_portfolio"] = self.portfolio_value
+            reward_debug["realized_pnl"] = realized
+            reward = reward_step
+            reward_debug["final_reward"] = reward
+
+            observation = self._get_observation()
+            info = self._get_info()
+            info["reward_debug"] = reward_debug
+            info.update(_risk_limit_info)
+
+            if self.done and self.current_step < self._ds_len():
+                if self.current_capital <= 1.0:
+                    reward = -1.0
+                elif self.portfolio_value < 1.0:
+                    reward = -0.5
+                observation = self._get_observation()
+                info = self._get_info()
+                info["reward_debug"] = reward_debug
+                info["early_termination"] = True
+                info.update(_risk_limit_info)
+                return observation, float(reward), True, False, info
+
+            if not np.all(np.isfinite(observation)):
+                bad = int(np.sum(~np.isfinite(observation)))
+                self.logger.error(
+                    f"NaN/Inf in observation at step {self.current_step}: "
+                    f"{bad} non-finite values — replacing with 0.0"
+                )
+                observation = np.nan_to_num(observation, nan=0.0, posinf=0.0, neginf=0.0)
+            if not np.isfinite(reward):
+                self.logger.error(
+                    f"NaN/Inf reward at step {self.current_step}: {reward} — replacing with 0.0"
+                )
+                reward = 0.0
+            return observation, float(reward), self.done, False, info
 
         # Calculate basic reward (change in portfolio value) using log returns with ratio clipping
         eps = 1e-8 # Small epsilon to prevent division by zero
@@ -1404,6 +1473,7 @@ class SingleAssetRLTradingEnv(gym.Env):
             "last_slippage": self.last_slippage,
             "regime_gate_fires": self._gate_fires,
             "regime_gate_active": self._bear_gate_active() if self.regime_gate_enabled else False,
+            "realized_pnl_this_step": self._realized_pnl_this_step,
         }
 
     def _calculate_portfolio_value(self, step: int) -> float:

--- a/scripts/smoke_train.py
+++ b/scripts/smoke_train.py
@@ -30,7 +30,8 @@ if args.config:
     ec = raw.get("env", {})
     for key in ("trading_fee", "apply_slippage", "slippage_factor", "cost_model",
                 "funding_rate_per_8h", "window_size", "max_position_size",
-                "sharpe_weight", "inactivity_penalty", "sharpe_clip_value"):
+                "sharpe_weight", "inactivity_penalty", "sharpe_clip_value",
+                "reward_function"):
         if key in ec:
             env_kwargs[key] = ec[key]
     print(f"Config loaded from {args.config}: {env_kwargs}")
@@ -73,7 +74,8 @@ print(
     f"sharpe_clip_value={getattr(env, 'sharpe_clip_value', 10.0)}, "
     f"regime_gate_enabled={getattr(env, 'regime_gate_enabled', False)}, "
     f"regime_gate_mode={getattr(env, 'regime_gate_mode', 'close')}, "
-    f"regime_gate_bear_threshold={getattr(env, 'regime_gate_bear_threshold', 0.5)}"
+    f"regime_gate_bear_threshold={getattr(env, 'regime_gate_bear_threshold', 0.5)}, "
+    f"reward_function={getattr(env, 'reward_function', 'sharpe_ratio')}"
 )
 
 agent = create_agent(
@@ -119,4 +121,7 @@ print(f"capital min/mean:    {capitals.min():.2f} / {capitals.mean():.2f}")
 print(f"NEGATIVE capital:    {neg_capital} steps {'(BUG STILL PRESENT!)' if neg_capital else '(OK)'}")
 if getattr(env, 'regime_gate_enabled', False):
     print(f"regime_gate_fires:   {getattr(env, '_gate_fires', 0)} (last episode)")
+if getattr(env, 'reward_function', '') == 'realized_pnl':
+    n_realized = sum(1 for r in rewards if abs(r) > 1e-9)
+    print(f"realized_pnl trades: {n_realized} / {len(rewards)} steps")
 print("=" * 60)

--- a/tests/test_realized_pnl_reward.py
+++ b/tests/test_realized_pnl_reward.py
@@ -1,0 +1,150 @@
+"""Phase 8-Gamma G2: realized-PnL reward function tests."""
+import numpy as np
+import pandas as pd
+import pytest
+
+from envs.single_asset_rl_env import SingleAssetRLTradingEnv
+
+
+def _make_data(n=200, price_drift=0.0):
+    """Deterministic linear-drift price for predictable PnL."""
+    base = np.linspace(100.0, 100.0 + price_drift * n, n)
+    return pd.DataFrame(
+        {
+            "$open": base,
+            "$high": base * 1.001,
+            "$low": base * 0.999,
+            "$close": base,
+            "$volume": np.ones(n) * 1000.0,
+        }
+    )
+
+
+def _make_env(data, **kw):
+    defaults = dict(
+        initial_capital=100_000.0,
+        window_size=20,
+        min_episode_steps=30,
+        partial_fills=False,
+        apply_slippage=False,
+        max_position_size=1.0,
+        reward_function="realized_pnl",
+        risk_adjusted_reward=False,
+        sharpe_weight=0.0,
+    )
+    defaults.update(kw)
+    return SingleAssetRLTradingEnv(data=data, **defaults)
+
+
+# ---- Test 1: hold gives zero reward ----
+def test_hold_gives_zero_reward():
+    """When agent holds (no position change), reward must be 0."""
+    env = _make_env(_make_data(100, price_drift=1.0))
+    env.reset(seed=0)
+    rewards = []
+    for _ in range(20):
+        obs, r, term, trunc, info = env.step(np.array([0.0], dtype=np.float32))
+        rewards.append(r)
+        if term or trunc:
+            break
+    assert all(abs(r) < 1e-9 for r in rewards), (
+        f"Hold-only episode should give zero reward; got {rewards}"
+    )
+
+
+# ---- Test 2: position open gives zero reward ----
+def test_open_position_gives_zero_reward():
+    """Opening a position is not a realization — reward = 0."""
+    env = _make_env(_make_data(100))
+    env.reset(seed=0)
+    obs, r, _, _, _ = env.step(np.array([1.0], dtype=np.float32))
+    assert abs(r) < 1e-9, f"Opening position should give zero reward, got {r}"
+    assert env.current_position > 0
+
+
+# ---- Test 3: profitable close gives positive reward ----
+def test_profitable_long_close_gives_positive_reward():
+    """Open long, hold while price rises, close → positive realized PnL reward."""
+    env = _make_env(_make_data(100, price_drift=1.0))
+    env.reset(seed=0)
+    env.step(np.array([1.0], dtype=np.float32))  # open long at ~100
+    for _ in range(10):
+        env.step(np.array([0.0], dtype=np.float32))
+    obs, r, _, _, info = env.step(np.array([-1.0], dtype=np.float32))  # close
+    assert r > 0, f"Profitable close should give positive reward, got {r}"
+    assert info["realized_pnl_this_step"] > 0
+
+
+# ---- Test 4: losing close gives negative reward ----
+def test_losing_long_close_gives_negative_reward():
+    """Open long, price falls, close → negative reward."""
+    env = _make_env(_make_data(100, price_drift=-1.0))
+    env.reset(seed=0)
+    env.step(np.array([1.0], dtype=np.float32))
+    for _ in range(10):
+        env.step(np.array([0.0], dtype=np.float32))
+    obs, r, _, _, info = env.step(np.array([-1.0], dtype=np.float32))
+    assert r < 0, f"Losing close should give negative reward, got {r}"
+
+
+# ---- Test 5: short close on price drop gives positive reward ----
+def test_short_close_profit_on_price_drop():
+    """Open short, price drops, close → positive realized PnL."""
+    env = _make_env(_make_data(100, price_drift=-1.0))
+    env.reset(seed=0)
+    env.step(np.array([-1.0], dtype=np.float32))
+    for _ in range(10):
+        env.step(np.array([0.0], dtype=np.float32))
+    obs, r, _, _, info = env.step(np.array([1.0], dtype=np.float32))
+    assert r > 0, f"Profitable short close should give positive reward, got {r}"
+
+
+# ---- Test 6: partial close realizes proportional PnL ----
+def test_partial_close_realizes_proportional_pnl():
+    """Open full long, halve position when profitable → positive reward."""
+    env = _make_env(_make_data(100, price_drift=1.0))
+    env.reset(seed=0)
+    env.step(np.array([1.0], dtype=np.float32))  # full long
+    pos_before = env.current_position
+    for _ in range(5):
+        env.step(np.array([0.0], dtype=np.float32))
+    obs, r, _, _, info = env.step(np.array([-0.5], dtype=np.float32))  # halve
+    assert r > 0, f"Partial close should give positive reward, got {r}"
+    assert env.current_position < pos_before
+
+
+# ---- Test 7: reward magnitude = realized PnL / initial_capital ----
+def test_reward_magnitude_normalized():
+    """Reward = realized_pnl / initial_capital (portfolio fraction)."""
+    env = _make_env(_make_data(100, price_drift=1.0), initial_capital=100_000.0)
+    env.reset(seed=0)
+    env.step(np.array([1.0], dtype=np.float32))
+    for _ in range(5):
+        env.step(np.array([0.0], dtype=np.float32))
+    obs, r, _, _, info = env.step(np.array([-1.0], dtype=np.float32))
+    realized = info["realized_pnl_this_step"]
+    expected = float(np.clip(realized / 100_000.0, -5.0, 5.0))
+    assert abs(r - expected) < 1e-6, (
+        f"reward should be clip(realized_pnl/initial_capital, ±5): {r} vs {expected}"
+    )
+
+
+# ---- Test 8: backward compat (sharpe_ratio path unchanged) ----
+def test_sharpe_ratio_path_unchanged_when_realized_pnl_not_set():
+    """reward_function='sharpe_ratio' (default) gives non-zero reward on hold
+    while price is moving — regression guard for the existing path."""
+    data = _make_data(100, price_drift=1.0)
+    env = SingleAssetRLTradingEnv(
+        data=data,
+        initial_capital=100_000.0,
+        window_size=20,
+        partial_fills=False,
+        apply_slippage=False,
+        reward_function="sharpe_ratio",
+    )
+    env.reset(seed=0)
+    env.step(np.array([1.0], dtype=np.float32))  # open long
+    for _ in range(5):
+        obs, r, _, _, _ = env.step(np.array([0.0], dtype=np.float32))
+    # Hold while price rises — sharpe-based reward should be nonzero
+    assert abs(r) > 1e-6, "sharpe_ratio path should give nonzero hold reward on rising price"

--- a/training/env_factory.py
+++ b/training/env_factory.py
@@ -439,6 +439,8 @@ def create_env(
             funding_rate_per_8h=env_config.get("funding_rate_per_8h", 0.0001),
             inactivity_penalty=env_config.get("inactivity_penalty", 0.0),
             sharpe_clip_value=env_config.get("sharpe_clip_value", 10.0),
+            # Phase 8-Gamma G2: reward function selector
+            reward_function=env_config.get("reward_function", "sharpe_ratio"),
             # Phase 8-Gamma G1: regime gate pass-through
             regime_track=regime_track,
             regime_gate_enabled=regime_gate_cfg.get("enabled", False),


### PR DESCRIPTION
## §0 Motivation

**G1 NO-GO at 1M**: G1_refuse 1M (-0.11% all / 1.48 trades/ep) ≈ B0_v2 1M (-0.14% all / 1.46 trades/ep). Δ = noise.

**Root cause confirmed**: trades/ep collapse 50k→1M (6→1.5, 4× reduction) occurs in **every variant** — B0, B1, B2, B3, G1_close, G1_refuse — regardless of reward magnitude or regime gating. This is a structural reward problem: sharpe-based reward has nonzero value when holding (portfolio moves with price) → policy converges to near-hold at 1M to avoid downside sharpe.

**G2 hypothesis**: zero reward on hold → policy must trade to collect reward → trade frequency preserved through 1M.

## §1 Audit results

Existing `_entry_price` (line ~655) already tracks entry price for stop-loss. `_prev_position` (line ~650) captures pre-trade position. `actual_change` gives direction. These three are sufficient for realized PnL with no new state.

Realized PnL formula:
- Long reduce (`_prev_position > 0`, `actual_change < 0`): `closed_size × (exec_price − entry_price)`
- Short reduce (`_prev_position < 0`, `actual_change > 0`): `closed_size × (entry_price − exec_price)`
- Position increase or flat → realized = 0
- Position flip: realizes the old side only (up to `|prev_position|`); new entry_price handled by existing line 659.

Computed **before** `_entry_price` update so old entry price is used.

## Changes (~160 LoC, 6 files)

| File | Change |
|---|---|
| `envs/single_asset_rl_env.py` | `reward_function` param + validator; realized PnL tracking in step(); reward branch (bypasses sharpe overlay); reset init; `_get_info` field |
| `config/schema.py` | `reward_function` field validator (`{"sharpe_ratio","log_return","realized_pnl"}`) |
| `training/env_factory.py` | `reward_function=env_config.get("reward_function","sharpe_ratio")` |
| `config/phase8_gamma/G2_realized_pnl.yaml` | Diagnostic config (futures_maker, no regime gate, `reward_function: realized_pnl`) |
| `tests/test_realized_pnl_reward.py` | 8 unit tests |
| `scripts/smoke_train.py` | `reward_function` in config extraction + effective env print + realized trade count |

**Existing sharpe_ratio path unchanged** — reward calculation block is guarded by `if self.reward_function == "realized_pnl":` returning early; existing code below is untouched.

## Smoke results (§3)

- **§3.1** `pytest tests/test_realized_pnl_reward.py -v` → **8/8 pass** ✓
- **§3.2** Regression (capital_floor_grace, regime_gate, aggregate_wf, train_pipeline_random_start) → **69/69 pass** ✓
- **§3.3** `smoke_train.py --config G2_realized_pnl.yaml`:
  - `reward_function=realized_pnl` ✓
  - `realized_pnl trades: 740 / 1500 steps` (hold steps = 0 reward, trade steps = nonzero) ✓
  - No NaN/Inf, no negative capital ✓
- **§3.4** `smoke_train.py` (default): `reward_function=sharpe_ratio`, existing path untouched ✓
- **§3.5** `run_wf.py --n_splits 2 --total_timesteps 5000 --config G2_realized_pnl.yaml`:
  - `=== RESULT ===` prints normally ✓
  - `oos_trade_count_mean=28.2` (active trading at 5k) ✓

## §5 Verdict matrix — 50k gating metric

**Most important metric: trades/ep** (proxy for 1M scaling stability)

| trades/ep @ 50k | Risk of 1M collapse | Action |
|---|---|---|
| **≥ 6** (sharpe baseline level) | Low | **G2 1M go** |
| 4–6 | Medium | 1M go + draft G3 plan |
| 2–4 | High | G2.1 with inactivity_penalty |
| **< 2** | **Hypothesis falsified** | G3 features or different lever |

Baseline for comparison: B0_v2_50k (post-grace-fix) trades/ep ≈ 6.17, all ≈ -0.03%.

## Next step (operator)

```powershell
# ~30 min on trading-pc
$env:PYTHONIOENCODING = "utf-8"
cd ~/desktop/trading_bot
git checkout main; git pull
mkdir -Force logs/phase8_gamma_g2
Start-Process powershell -ArgumentList "-NoProfile -Command python run_wf.py --config config/phase8_gamma/G2_realized_pnl.yaml --n_splits 12 --total_timesteps 50000 *> logs\phase8_gamma_g2\G2_50k.log" -WindowStyle Hidden
```

Aggregator after run:
```bash
PYTHONPATH=. python scripts/aggregate_wf_results.py     --logs logs/phase8_gamma_g2/G2_50k.log            logs/phase8_post_grace_fix/B0_50k_v2.log     --variant-names G2 B0_v2     --bull-folds 0,2,5,8,11 --bear-folds 1,3,4,6,7,9,10     --detail G2
```