### PR TITLE
feat(aggregator): fixed-start metric output for G2 cross-check

### DIFF
--- a/scripts/aggregate_wf_results.py
+++ b/scripts/aggregate_wf_results.py
@@ -75,6 +75,22 @@ class VariantResult:
     def folds_positive(self) -> int:
         return sum(1 for f in self.folds if f.oos_total_return_random > 0)
 
+    # Fixed-start equivalents (source: oos_total_return, not oos_total_return_random)
+    def all_mean(self) -> float:
+        vals = self._fold_values("oos_total_return")
+        return float(sum(vals) / len(vals)) if vals else float("nan")
+
+    def bull_mean(self, bull_indices: List[int]) -> float:
+        vals = self._fold_values("oos_total_return", bull_indices)
+        return float(sum(vals) / len(vals)) if vals else float("nan")
+
+    def bear_mean(self, bear_indices: List[int]) -> float:
+        vals = self._fold_values("oos_total_return", bear_indices)
+        return float(sum(vals) / len(vals)) if vals else float("nan")
+
+    def folds_positive_fixed(self) -> int:
+        return sum(1 for f in self.folds if f.oos_total_return > 0)
+
     def trades_per_ep(self) -> float:
         vals = self._fold_values("oos_trade_count_random_mean")
         return float(sum(vals) / len(vals)) if vals else float("nan")
@@ -331,6 +347,32 @@ def print_table(
                 )
 
 
+def print_fixed_start_table(
+    variants: List[VariantResult],
+    bull_indices: List[int],
+    bear_indices: List[int],
+) -> None:
+    """Print fixed-start OOS return table — cross-check for random-start results."""
+    print("\nFixed-start OOS return (eval_episodes=N at fold-start):")
+    header = (
+        f"{'Variant':<12} {'All mean(fix)':>14} {'Bull mean':>10} "
+        f"{'Bear mean':>10} {'Folds+':>7}"
+    )
+    sep = "-" * len(header)
+    print(sep)
+    print(header)
+    print(sep)
+    for v in variants:
+        print(
+            f"{v.name:<12} "
+            f"{_pct(v.all_mean()):>14} "
+            f"{_pct(v.bull_mean(bull_indices)):>10} "
+            f"{_pct(v.bear_mean(bear_indices)):>10} "
+            f"{v.folds_positive_fixed():>5}/{v.n_folds():<2}"
+        )
+    print(sep)
+
+
 def print_maxdd_table(
     variants: List[VariantResult],
     bull_indices: List[int],
@@ -475,6 +517,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     print()
 
     print_table(variants, bull_indices, bear_indices)
+    print_fixed_start_table(variants, bull_indices, bear_indices)
     print_maxdd_table(variants, bull_indices, bear_indices)
 
     if args.detail:

--- a/tests/test_aggregate_wf_results.py
+++ b/tests/test_aggregate_wf_results.py
@@ -26,6 +26,7 @@ from aggregate_wf_results import (
     _parse_fold_range,
     _FOLD_RE,
     print_maxdd_table,
+    print_fixed_start_table,
 )
 
 
@@ -559,3 +560,63 @@ class TestGateMetricFields:
         g = matches[0].groupdict()
         assert g.get("gate_fires") is None
         assert g.get("gate_frac") is None
+
+
+# ---------------------------------------------------------------------------
+# Fixed-start stats (oos_total_return field)
+# ---------------------------------------------------------------------------
+
+def _make_variant_fixed(name: str, fixed_returns: list) -> VariantResult:
+    """Build a VariantResult with distinct fixed-start (oos_total_return) values.
+
+    oos_total_return_random is deliberately zeroed so tests confirm the
+    fixed-start methods read from the correct field.
+    """
+    folds = [
+        ParsedFold(
+            fold_idx=i,
+            is_sharpe=0.0,
+            oos_sharpe=0.0,
+            oos_max_drawdown=0.0,
+            oos_total_return=r,
+            oos_sharpe_random=0.0,
+            oos_total_return_random=0.0,  # distinct from fixed — ensures correct field is read
+            oos_trade_count_mean=2.0,
+            oos_trade_count_random_mean=2.0,
+        )
+        for i, r in enumerate(fixed_returns)
+    ]
+    return VariantResult(name=name, folds=folds)
+
+
+class TestFixedStartStats:
+    def test_all_mean(self):
+        v = _make_variant_fixed("X", [0.01, -0.02, 0.03])
+        assert abs(v.all_mean() - (0.01 - 0.02 + 0.03) / 3) < 1e-9
+
+    def test_bull_mean(self):
+        v = _make_variant_fixed("X", [0.05, 0.04, -0.03, -0.01])
+        assert abs(v.bull_mean([0, 1]) - 0.045) < 1e-9
+
+    def test_bear_mean(self):
+        v = _make_variant_fixed("X", [0.05, 0.04, -0.03, -0.01])
+        assert abs(v.bear_mean([2, 3]) - (-0.02)) < 1e-9
+
+    def test_folds_positive_fixed(self):
+        v = _make_variant_fixed("X", [0.01, -0.02, 0.03, -0.01, 0.02])
+        assert v.folds_positive_fixed() == 3
+
+
+class TestFixedStartTable:
+    def test_header_and_variant_rows_present(self, capsys):
+        g2 = _make_variant_fixed("G2", [0.01, -0.02, 0.03] * 4)
+        b0 = _make_variant_fixed("B0", [-0.01] * 12)
+        print_fixed_start_table(
+            [g2, b0],
+            bull_indices=[0, 2, 4, 6, 8],
+            bear_indices=[1, 3, 5, 7, 9, 10, 11],
+        )
+        out = capsys.readouterr().out
+        assert "Fixed-start" in out
+        assert "G2" in out
+        assert "B0" in out


### PR DESCRIPTION
## Summary

- Adds `all_mean()`, `bull_mean()`, `bear_mean()`, `folds_positive_fixed()` to `VariantResult` — fixed-start counterparts of the existing `*_random` methods, reading `oos_total_return` (already parsed from logs, just never surfaced)
- Adds `print_fixed_start_table()` that mirrors `print_table()` layout but with fixed-start values; printed between the existing random-start and MaxDD tables
- Output order: random table → **fixed-start table** → MaxDD table → per-fold detail

## Why

G2 1M results were only visible via random-start metrics. The walk-forward driver always runs both evals per fold (`oos_total_return` = fixed-start), but the aggregator only printed random-start. This PR surfaces the fixed-start column so the operator can run the existing G2 log files through the updated aggregator to cross-check robustness without re-training.

## Test plan

- [ ] `pytest tests/test_aggregate_wf_results.py -q` → 54 passed (was 49; +5 new)
- [ ] `TestFixedStartStats` (4 unit): `all_mean`, `bull_mean`, `bear_mean`, `folds_positive_fixed` each verified against synthetic `ParsedFold`s with `oos_total_return_random=0.0` to confirm correct field is read
- [ ] `TestFixedStartTable` (1 smoke): capsys confirms "Fixed-start" header + G2/B0 rows present
- [ ] Operator to manually apply to G2 1M log files on trading-pc/archive and confirm sensible values

🤖 Generated with [Claude Code](https://claude.com/claude-code)