### PR TITLE
feat(stats): statistical evidence computation for live gate (B2-B5)

### DIFF
--- a/scripts/compute_statistical_evidence.py
+++ b/scripts/compute_statistical_evidence.py
@@ -1,0 +1,219 @@
+"""Compute statistical evidence metrics for live gate (B2-B5).
+
+Reads a walk-forward log or per-fold OOS return CSV and emits:
+  net_sharpe, dsr, bootstrap_ci_lower, permutation_p
+
+These fields are consumed by deployment/governance/live_signal_gate.py.
+
+Usage
+-----
+# From a walk-forward log:
+python scripts/compute_statistical_evidence.py --log logs/G2_1M.log
+
+# From a per-fold CSV (fold_idx, oos_total_return, oos_total_return_random):
+python scripts/compute_statistical_evidence.py --returns-csv results.csv
+
+# Write JSON to file:
+python scripts/compute_statistical_evidence.py --log logs/G2_1M.log --output evidence.json
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Import log parser from aggregate_wf_results (same scripts/ dir)
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, str(Path(__file__).parent))
+from aggregate_wf_results import parse_log  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Core statistics
+# ---------------------------------------------------------------------------
+
+def _sharpe(returns: np.ndarray) -> float:
+    n = len(returns)
+    if n < 2:
+        return float("nan")
+    std = float(returns.std(ddof=1))
+    # Guard against zero / near-zero std (identical returns → infinite Sharpe → undefined)
+    if std < 1e-12:
+        return float("nan")
+    return float(returns.mean() / std * math.sqrt(n))
+
+
+def net_sharpe(returns: np.ndarray) -> float:
+    """Sample Sharpe of fold returns: mean/std * sqrt(N)."""
+    return _sharpe(returns)
+
+
+def dsr(
+    returns: np.ndarray,
+    n_permutations: int = 1000,
+    rng: Optional[np.random.Generator] = None,
+) -> float:
+    """Deflated Sharpe: z-score of observed Sharpe vs sign-flip null.
+
+    Permutes return signs to build H0 distribution; returns how many
+    std-devs the observed Sharpe sits above the null mean.
+    """
+    sr_obs = _sharpe(returns)
+    if math.isnan(sr_obs):
+        return float("nan")
+    if rng is None:
+        rng = np.random.default_rng(42)
+
+    signs = rng.choice(np.array([-1.0, 1.0]), size=(n_permutations, len(returns)))
+    permuted_returns = signs * returns[np.newaxis, :]
+    permuted_srs = np.array([_sharpe(row) for row in permuted_returns])
+    valid = permuted_srs[~np.isnan(permuted_srs)]
+    if len(valid) < 2:
+        return float("nan")
+
+    std = float(valid.std(ddof=1))
+    if std == 0.0:
+        return float("nan")
+    return float((sr_obs - float(valid.mean())) / std)
+
+
+def bootstrap_ci(
+    returns: np.ndarray,
+    n_bootstrap: int = 1000,
+    rng: Optional[np.random.Generator] = None,
+) -> Tuple[float, float, float]:
+    """Bootstrap 95% CI of mean return (with replacement).
+
+    Returns (mean, lower_2.5%, upper_97.5%).
+    """
+    n = len(returns)
+    if rng is None:
+        rng = np.random.default_rng(42)
+
+    idx = rng.integers(0, n, size=(n_bootstrap, n))
+    boot_means = returns[idx].mean(axis=1)
+    return (
+        float(returns.mean()),
+        float(np.percentile(boot_means, 2.5)),
+        float(np.percentile(boot_means, 97.5)),
+    )
+
+
+def permutation_p(
+    returns: np.ndarray,
+    n_permutations: int = 1000,
+    rng: Optional[np.random.Generator] = None,
+) -> float:
+    """Sign-flip permutation p-value for H0: no positive edge.
+
+    p = (count[permuted_mean >= observed_mean] + 1) / (n + 1)
+    """
+    obs_mean = float(returns.mean())
+    if rng is None:
+        rng = np.random.default_rng(42)
+
+    signs = rng.choice(np.array([-1.0, 1.0]), size=(n_permutations, len(returns)))
+    permuted_means = (signs * returns[np.newaxis, :]).mean(axis=1)
+    count = int((permuted_means >= obs_mean).sum())
+    return (count + 1) / (n_permutations + 1)
+
+
+# ---------------------------------------------------------------------------
+# Input helpers
+# ---------------------------------------------------------------------------
+
+def _returns_from_log(path: Path) -> Tuple[np.ndarray, np.ndarray]:
+    """Return (fixed_start_returns, random_start_returns) from a WF log."""
+    folds = parse_log(path)
+    fixed = np.array([f.oos_total_return for f in folds], dtype=float)
+    random = np.array([f.oos_total_return_random for f in folds], dtype=float)
+    return fixed, random
+
+
+def _returns_from_csv(path: Path) -> Tuple[np.ndarray, np.ndarray]:
+    """Return (fixed_start_returns, random_start_returns) from a CSV.
+
+    Expected columns: fold_idx, oos_total_return, oos_total_return_random
+    """
+    fixed: List[float] = []
+    random: List[float] = []
+    with open(path, newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            fixed.append(float(row["oos_total_return"]))
+            random.append(float(row["oos_total_return_random"]))
+    return np.array(fixed, dtype=float), np.array(random, dtype=float)
+
+
+def _compute(returns: np.ndarray, seed: int, n_perm: int, n_boot: int) -> Dict:
+    rng = np.random.default_rng(seed)
+    rng_dsr = np.random.default_rng(seed)
+    rng_boot = np.random.default_rng(seed + 1)
+    rng_perm = np.random.default_rng(seed + 2)
+
+    sr = net_sharpe(returns)
+    d = dsr(returns, n_permutations=n_perm, rng=rng_dsr)
+    b_mean, b_lower, b_upper = bootstrap_ci(returns, n_bootstrap=n_boot, rng=rng_boot)
+    p = permutation_p(returns, n_permutations=n_perm, rng=rng_perm)
+
+    return {
+        "net_sharpe": round(sr, 6),
+        "dsr": round(d, 6),
+        "bootstrap_ci_mean": round(b_mean, 6),
+        "bootstrap_ci_lower": round(b_lower, 6),
+        "bootstrap_ci_upper": round(b_upper, 6),
+        "permutation_p": round(p, 6),
+        "n_folds": len(returns),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Compute statistical evidence metrics for live gate (B2-B5)."
+    )
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--log", metavar="FILE", help="walk-forward log file (run_wf.py output)")
+    src.add_argument("--returns-csv", metavar="FILE", help="per-fold CSV with fold_idx, oos_total_return, oos_total_return_random")
+    parser.add_argument("--output", metavar="FILE", help="write JSON to this path (also printed to stdout)")
+    parser.add_argument("--seed", type=int, default=42, help="random seed (default: 42)")
+    parser.add_argument("--n-permutations", type=int, default=1000, help="permutation count for DSR and p-value (default: 1000)")
+    parser.add_argument("--n-bootstrap", type=int, default=1000, help="bootstrap resample count (default: 1000)")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.log:
+            fixed, random = _returns_from_log(Path(args.log))
+        else:
+            fixed, random = _returns_from_csv(Path(args.returns_csv))
+    except (ValueError, OSError, KeyError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    result = {
+        "random_start": _compute(random, args.seed, args.n_permutations, args.n_bootstrap),
+        "fixed_start": _compute(fixed, args.seed, args.n_permutations, args.n_bootstrap),
+    }
+
+    payload = json.dumps(result, indent=2)
+    print(payload)
+    if args.output:
+        Path(args.output).write_text(payload)
+        print(f"\nWritten to {args.output}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_compute_statistical_evidence.py
+++ b/tests/test_compute_statistical_evidence.py
@@ -1,0 +1,264 @@
+"""Unit and smoke tests for scripts/compute_statistical_evidence.py."""
+
+import csv
+import json
+import math
+import sys
+import textwrap
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Script-under-test lives in scripts/, not a package — import via sys.path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from compute_statistical_evidence import (
+    _compute,
+    _returns_from_csv,
+    _returns_from_log,
+    bootstrap_ci,
+    dsr,
+    main,
+    net_sharpe,
+    permutation_p,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+def _fold_repr(
+    fold_idx: int = 0,
+    oos_total_return: float = 0.02,
+    oos_total_return_random: float = 0.018,
+) -> str:
+    return (
+        f"FoldResult(fold_idx={fold_idx}, train_size=600, test_size=120, "
+        f"is_sharpe=0.5, oos_sharpe=0.3, oos_max_drawdown=0.05, "
+        f"oos_total_return={oos_total_return}, oos_sharpe_random=0.25, "
+        f"oos_total_return_random={oos_total_return_random}, "
+        f"oos_trade_count_mean=2.0, oos_trade_count_random_mean=2.5, metrics={{}})"
+    )
+
+
+def _make_log(folds_returns: list[tuple[float, float]], tmp_path: Path) -> Path:
+    """Write a minimal WF log with given (fixed, random) returns per fold."""
+    reprs = [
+        _fold_repr(fold_idx=i, oos_total_return=f, oos_total_return_random=r)
+        for i, (f, r) in enumerate(folds_returns)
+    ]
+    content = "=== RESULT ===\nWalkForwardResult(folds=[" + ", ".join(reprs) + "])\n"
+    p = tmp_path / "run.log"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _make_csv(folds_returns: list[tuple[float, float]], tmp_path: Path) -> Path:
+    """Write a per-fold OOS return CSV."""
+    p = tmp_path / "returns.csv"
+    with open(p, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["fold_idx", "oos_total_return", "oos_total_return_random"])
+        writer.writeheader()
+        for i, (f, r) in enumerate(folds_returns):
+            writer.writerow({"fold_idx": i, "oos_total_return": f, "oos_total_return_random": r})
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Unit: net_sharpe
+# ---------------------------------------------------------------------------
+
+class TestNetSharpe:
+    def test_all_positive_constant(self):
+        # All returns identical → std = 0 → nan
+        r = np.ones(12) * 0.02
+        assert math.isnan(net_sharpe(r))
+
+    def test_positive_with_variance(self):
+        # All positive returns → sharpe should be positive
+        r = np.array([0.01, 0.02, 0.03, 0.01, 0.02, 0.03] * 2, dtype=float)
+        sr = net_sharpe(r)
+        assert sr > 0.0
+
+    def test_all_negative(self):
+        r = np.array([-0.02] * 5 + [-0.01] * 7, dtype=float)
+        sr = net_sharpe(r)
+        assert sr < 0.0
+
+    def test_single_observation(self):
+        assert math.isnan(net_sharpe(np.array([0.05])))
+
+    def test_known_value(self):
+        # mean=0.02, std=0.01 (ddof=1), N=12 → sharpe = 0.02/0.01*sqrt(12)
+        # Build returns where mean and std match (approximately)
+        r = np.array([0.02 + 0.01 * (i - 5.5) / 3.0 for i in range(12)])
+        sr = net_sharpe(r)
+        expected = r.mean() / r.std(ddof=1) * math.sqrt(12)
+        assert abs(sr - expected) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Unit: dsr
+# ---------------------------------------------------------------------------
+
+class TestDSR:
+    def test_strongly_positive_returns_positive_dsr(self):
+        # Strong positive returns should sit above the sign-flip null
+        r = np.array([0.05] * 6 + [0.03] * 6, dtype=float)
+        d = dsr(r, n_permutations=1000, rng=np.random.default_rng(0))
+        assert d > 0.0
+
+    def test_strongly_negative_returns_negative_dsr(self):
+        r = np.array([-0.05] * 6 + [-0.03] * 6, dtype=float)
+        d = dsr(r, n_permutations=1000, rng=np.random.default_rng(0))
+        assert d < 0.0
+
+    def test_constant_returns_nan(self):
+        r = np.ones(12) * 0.01
+        assert math.isnan(dsr(r))
+
+    def test_reproducible_with_seed(self):
+        r = np.array([0.01 * i for i in range(1, 13)], dtype=float)
+        d1 = dsr(r, n_permutations=200, rng=np.random.default_rng(99))
+        d2 = dsr(r, n_permutations=200, rng=np.random.default_rng(99))
+        assert d1 == d2
+
+
+# ---------------------------------------------------------------------------
+# Unit: bootstrap_ci
+# ---------------------------------------------------------------------------
+
+class TestBootstrapCI:
+    def test_all_positive_ci_lower_positive(self):
+        r = np.array([0.02, 0.03, 0.025, 0.01, 0.02, 0.015] * 2, dtype=float)
+        _, lower, upper = bootstrap_ci(r, n_bootstrap=2000, rng=np.random.default_rng(7))
+        assert lower > 0.0
+        assert upper > lower
+
+    def test_all_negative_ci_upper_negative(self):
+        r = np.array([-0.02, -0.03, -0.01] * 4, dtype=float)
+        _, lower, upper = bootstrap_ci(r, n_bootstrap=2000, rng=np.random.default_rng(7))
+        assert upper < 0.0
+
+    def test_mean_matches_sample_mean(self):
+        r = np.array([0.01, 0.02, 0.03, 0.04, 0.05, 0.01] * 2, dtype=float)
+        mean, _, _ = bootstrap_ci(r, n_bootstrap=500, rng=np.random.default_rng(0))
+        assert abs(mean - float(r.mean())) < 1e-12
+
+    def test_ci_contains_mean(self):
+        r = np.array([0.01 * i for i in range(1, 13)], dtype=float)
+        mean, lower, upper = bootstrap_ci(r, n_bootstrap=2000, rng=np.random.default_rng(5))
+        assert lower <= mean <= upper
+
+
+# ---------------------------------------------------------------------------
+# Unit: permutation_p
+# ---------------------------------------------------------------------------
+
+class TestPermutationP:
+    def test_strongly_positive_small_p(self):
+        # All-positive returns → almost no sign-flip permutation will match
+        r = np.array([0.04, 0.05, 0.03, 0.06, 0.04, 0.05] * 2, dtype=float)
+        p = permutation_p(r, n_permutations=1000, rng=np.random.default_rng(42))
+        assert p < 0.05
+
+    def test_zero_mean_p_near_half(self):
+        # Symmetric returns around 0 → p ≈ 0.5
+        r = np.array([-0.02, 0.02, -0.01, 0.01, -0.03, 0.03] * 2, dtype=float)
+        p = permutation_p(r, n_permutations=2000, rng=np.random.default_rng(42))
+        assert 0.3 < p < 0.7
+
+    def test_output_in_range(self):
+        r = np.array([0.01 * i for i in range(1, 13)], dtype=float)
+        p = permutation_p(r, n_permutations=500, rng=np.random.default_rng(0))
+        assert 0.0 < p <= 1.0
+
+    def test_formula_denominator(self):
+        # With n_permutations=99 and count=0, p = 1/100 = 0.01
+        r = np.ones(12) * 1.0  # large constant → no permutation can match
+        p = permutation_p(r, n_permutations=99, rng=np.random.default_rng(0))
+        assert p == pytest.approx(1 / 100, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Smoke: full pipeline on synthetic log
+# ---------------------------------------------------------------------------
+
+class TestSmokePipeline:
+    """End-to-end smoke test using a small synthetic log and CSV."""
+
+    _RETURNS = [
+        (0.020, 0.022),
+        (0.015, 0.018),
+        (-0.005, -0.003),
+        (0.030, 0.028),
+        (0.010, 0.012),
+        (0.025, 0.020),
+        (0.018, 0.017),
+        (-0.008, -0.006),
+        (0.022, 0.024),
+        (0.014, 0.016),
+        (0.028, 0.026),
+        (0.005, 0.007),
+    ]
+
+    def test_log_and_csv_agree(self, tmp_path):
+        log_dir = tmp_path / "log"
+        csv_dir = tmp_path / "csv"
+        log_dir.mkdir()
+        csv_dir.mkdir()
+
+        log_path = _make_log(self._RETURNS, log_dir)
+        csv_path = _make_csv(self._RETURNS, csv_dir)
+
+        fixed_log, random_log = _returns_from_log(log_path)
+        fixed_csv, random_csv = _returns_from_csv(csv_path)
+
+        np.testing.assert_allclose(fixed_log, fixed_csv, rtol=1e-9)
+        np.testing.assert_allclose(random_log, random_csv, rtol=1e-9)
+
+    def test_all_positive_returns_pass_gate_thresholds(self, tmp_path):
+        """With clearly positive fold returns (with variance), all gate criteria should pass."""
+        # Deliberately vary returns so std > 0 while keeping all values positive
+        pos = [(0.02 + 0.005 * (i % 3), 0.02 + 0.005 * (i % 3)) for i in range(12)]
+        log = _make_log(pos, tmp_path)
+        _, random = _returns_from_log(log)
+
+        result = _compute(random, seed=42, n_perm=1000, n_boot=1000)
+
+        assert result["net_sharpe"] > 0.5, f"net_sharpe={result['net_sharpe']}"
+        assert result["dsr"] > 0.0, f"dsr={result['dsr']}"
+        assert result["bootstrap_ci_lower"] > 0.0, f"ci_lower={result['bootstrap_ci_lower']}"
+        assert result["permutation_p"] < 0.05, f"perm_p={result['permutation_p']}"
+
+    def test_cli_log_input(self, tmp_path):
+        log = _make_log(self._RETURNS, tmp_path)
+        out_path = tmp_path / "out.json"
+        rc = main(["--log", str(log), "--output", str(out_path), "--seed", "42"])
+        assert rc == 0
+        data = json.loads(out_path.read_text())
+        assert "random_start" in data
+        assert "fixed_start" in data
+        for section in ("random_start", "fixed_start"):
+            assert "net_sharpe" in data[section]
+            assert "dsr" in data[section]
+            assert "bootstrap_ci_lower" in data[section]
+            assert "permutation_p" in data[section]
+            assert data[section]["n_folds"] == 12
+
+    def test_cli_csv_input(self, tmp_path):
+        csv_path = _make_csv(self._RETURNS, tmp_path)
+        rc = main(["--returns-csv", str(csv_path), "--seed", "42"])
+        assert rc == 0
+
+    def test_mixed_returns_sensible_output(self, tmp_path):
+        """Mixed-sign returns: CI should span zero, p should be moderate."""
+        log = _make_log(self._RETURNS, tmp_path)
+        _, random = _returns_from_log(log)
+        result = _compute(random, seed=42, n_perm=1000, n_boot=1000)
+
+        assert result["bootstrap_ci_lower"] < result["bootstrap_ci_upper"]
+        assert 0.0 < result["permutation_p"] <= 1.0
+        assert result["n_folds"] == 12


### PR DESCRIPTION
## Summary

- Adds `scripts/compute_statistical_evidence.py` (~160 LoC) that computes all four gate metrics needed to close B2-B5 blockers from `docs/phase8/live_readiness_G2.md`
- Adds `tests/test_compute_statistical_evidence.py` (22 tests, 100% pass) with per-metric unit tests and a full smoke test
- Zero regressions on the existing suite (15 pre-existing failures unchanged)

## Metrics computed

| Field | Definition | Gate threshold |
|---|---|---|
| `net_sharpe` | `mean(fold_returns) / std(fold_returns) * sqrt(N)` — aggregated OOS Sharpe, **not** mean of per-fold Sharpes | `> 0.5` |
| `dsr` | z-score of observed Sharpe vs sign-flip permuted null: `(SR_obs - mean(SR_perm)) / std(SR_perm)` | `> 0.0` |
| `bootstrap_ci_lower` | 2.5th percentile of 1000 bootstrap resamples of fold means | `> 0.0` |
| `permutation_p` | `(count[perm_mean ≥ obs_mean] + 1) / (n_perm + 1)` with sign-flip permutations | `< 0.05` |

Fixes the B2 methodological issue noted in the audit: the prior 0.459 value came from averaging per-fold `oos_sharpe_random` (which has episode-count artifacts). This script uses the **aggregated return series** across folds.

## Usage

```bash
# From a WF log:
python scripts/compute_statistical_evidence.py --log logs/G2_1M.log

# From a per-fold CSV:
python scripts/compute_statistical_evidence.py --returns-csv results.csv --output evidence.json
```

Output JSON keys match `live_signal_gate.py` field reads at lines 127–160. Both `random_start` and `fixed_start` sections are emitted so the operator can choose which to populate the evidence pack with.

## Test plan
- [x] `pytest tests/test_compute_statistical_evidence.py -q` → 22 passed
- [x] Full suite: 2825 passed, same 15 pre-existing failures, 0 new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)