### PR TITLE
feat(aggregator): memory-safe large-file parsing (UTF-16 LE support)

### DIFF
--- a/scripts/aggregate_wf_results.py
+++ b/scripts/aggregate_wf_results.py
@@ -180,21 +180,49 @@ def _parse_float(s: str) -> float:
     return float(s)
 
 
+# Tail window for large-file reads.  The RESULT block is always written last
+# by run_wf.py and is at most a few KB, so 2 MB is ample margin.
+_TAIL_BYTES = 2 * 1024 * 1024
+
+
 def _read_log_text(path: Path) -> str:
-    """Read a log file with BOM auto-detection.
+    """Read a log file with BOM auto-detection and memory-safe tail reading.
 
     PowerShell on Windows redirects (`*>` / `Out-File`) default to UTF-16 LE
-    with BOM (\\xff\\xfe), which UTF-8 decoding garbles. We sniff the first
-    bytes and pick the right codec; fall back to UTF-8 with replacement.
+    with BOM (\\xff\\xfe), producing files up to several GB. For files larger
+    than _TAIL_BYTES, only the last _TAIL_BYTES are read; run_wf.py always
+    writes ``=== RESULT ===`` at the very end of the log, so the tail contains
+    everything parse_log needs.  Small files are read in full (original path).
     """
-    raw = path.read_bytes()
-    if raw.startswith(b"\xff\xfe"):
-        return raw.decode("utf-16-le", errors="replace").lstrip("﻿")
-    if raw.startswith(b"\xfe\xff"):
-        return raw.decode("utf-16-be", errors="replace").lstrip("﻿")
-    if raw.startswith(b"\xef\xbb\xbf"):
-        return raw[3:].decode("utf-8", errors="replace")
-    return raw.decode("utf-8", errors="replace")
+    file_size = path.stat().st_size
+
+    with path.open("rb") as fh:
+        bom = fh.read(3)
+
+    if bom[:2] == b"\xff\xfe":
+        codec, bom_len, char_size = "utf-16-le", 2, 2
+    elif bom[:2] == b"\xfe\xff":
+        codec, bom_len, char_size = "utf-16-be", 2, 2
+    elif bom == b"\xef\xbb\xbf":
+        codec, bom_len, char_size = "utf-8", 3, 1
+    else:
+        codec, bom_len, char_size = "utf-8", 0, 1
+
+    content_size = file_size - bom_len
+    if content_size <= _TAIL_BYTES:
+        # File fits in the tail window — read in full and strip BOM bytes.
+        with path.open("rb") as fh:
+            raw = fh.read()
+        return raw[bom_len:].decode(codec, errors="replace")
+
+    # Large file: seek to last _TAIL_BYTES, aligned to the codec's code-unit size.
+    seek_pos = file_size - _TAIL_BYTES
+    if char_size == 2 and (seek_pos - bom_len) % 2 != 0:
+        seek_pos += 1  # step forward one byte to land on a UTF-16 code-unit boundary
+    with path.open("rb") as fh:
+        fh.seek(seek_pos)
+        raw_tail = fh.read()
+    return raw_tail.decode(codec, errors="replace")
 
 
 def parse_log(path: Path) -> List[ParsedFold]:

--- a/tests/test_aggregate_wf_results.py
+++ b/tests/test_aggregate_wf_results.py
@@ -17,6 +17,7 @@ import pytest
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
+import aggregate_wf_results as _agg_mod
 from aggregate_wf_results import (
     ParsedFold,
     VariantResult,
@@ -165,6 +166,80 @@ class TestParseLogHappyPath:
 # ---------------------------------------------------------------------------
 # parse_log: error cases
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# parse_log: large-file tail-read (memory-safe path)
+# ---------------------------------------------------------------------------
+
+class TestLargeFileSupport:
+    """_read_log_text tail-seek path: activated when content > _TAIL_BYTES.
+
+    We monkeypatch _TAIL_BYTES to a small value so a synthetic 8-KB file
+    triggers the large-file branch without allocating GB in CI.
+    """
+
+    # Preamble large enough to push content past the patched _TAIL_BYTES.
+    # "x" * 10000 encodes to 20000 UTF-16-LE bytes (10000 UTF-8 bytes).
+    _PREAMBLE = "x" * 10000 + "\n"
+    # Patched _TAIL_BYTES: larger than a 12-fold RESULT block (~6.3 KB UTF-16)
+    # but smaller than the preamble (20 KB UTF-16), so the tail path is exercised.
+    _SMALL_TAIL = 8192
+
+    def test_utf16_le_large_file_parses(self, tmp_path, monkeypatch):
+        """Large UTF-16 LE file: tail path finds and parses RESULT block."""
+        block = _make_result_block(n_folds=3)
+        text = self._PREAMBLE + block + "\n"
+        path = tmp_path / "large_utf16le.log"
+        path.write_bytes(b"\xff\xfe" + text.encode("utf-16-le"))
+
+        monkeypatch.setattr(_agg_mod, "_TAIL_BYTES", self._SMALL_TAIL)
+        folds = parse_log(path)
+        assert len(folds) == 3
+
+    def test_utf16_le_large_file_correct_values(self, tmp_path, monkeypatch):
+        """Numeric values parsed from the tail are identical to a small-file read."""
+        block = _make_result_block(n_folds=1, oos_total_return_random=0.0314)
+        text = self._PREAMBLE + block
+        path = tmp_path / "values_utf16le.log"
+        path.write_bytes(b"\xff\xfe" + text.encode("utf-16-le"))
+
+        monkeypatch.setattr(_agg_mod, "_TAIL_BYTES", self._SMALL_TAIL)
+        folds = parse_log(path)
+        assert len(folds) == 1
+        assert abs(folds[0].oos_total_return_random - 0.0314) < 1e-9
+
+    def test_utf8_large_file_parses(self, tmp_path, monkeypatch):
+        """Large plain UTF-8 file: tail path works correctly."""
+        block = _make_result_block(n_folds=3)
+        text = self._PREAMBLE + block + "\n"
+        path = tmp_path / "large_utf8.log"
+        path.write_text(text, encoding="utf-8")
+
+        monkeypatch.setattr(_agg_mod, "_TAIL_BYTES", self._SMALL_TAIL)
+        folds = parse_log(path)
+        assert len(folds) == 3
+
+    def test_small_file_full_read_path(self, tmp_path, monkeypatch):
+        """Files whose content fits in _TAIL_BYTES still parse correctly."""
+        block = _make_result_block(n_folds=2)
+        log = _write_log(tmp_path, block)
+        # _TAIL_BYTES larger than the file → full-read branch taken
+        monkeypatch.setattr(_agg_mod, "_TAIL_BYTES", 1024 * 1024)
+        folds = parse_log(log)
+        assert len(folds) == 2
+
+    def test_utf16_le_twelve_folds_large_file(self, tmp_path, monkeypatch):
+        """12-fold RESULT block is fully recovered from tail even with large preamble."""
+        block = _make_result_block(n_folds=12)
+        text = self._PREAMBLE + block
+        path = tmp_path / "twelve_utf16le.log"
+        path.write_bytes(b"\xff\xfe" + text.encode("utf-16-le"))
+
+        monkeypatch.setattr(_agg_mod, "_TAIL_BYTES", self._SMALL_TAIL)
+        folds = parse_log(path)
+        assert len(folds) == 12
+        assert [f.fold_idx for f in folds] == list(range(12))
+
 
 class TestParseLogEncodings:
     """PowerShell on Windows defaults to UTF-16 LE for `*>` redirects;


### PR DESCRIPTION
## Summary
- `_read_log_text` now tail-seeks the last 2 MB instead of calling `path.read_bytes()` on the whole file — eliminates OOM on 1-4 GB PowerShell UTF-16 LE redirect logs on Mac
- BOM sniffing unchanged; UTF-16 LE / BE alignment preserved via a 1-byte seek correction when the seek position lands on an odd code-unit boundary
- `compute_statistical_evidence.py` gets the fix automatically via its existing `from aggregate_wf_results import parse_log` import — no changes needed there

## How it works
`run_wf.py` always writes `=== RESULT ===` at the very end of the log. The 2 MB tail window is ~300× larger than a full 12-fold RESULT block (~6.3 KB UTF-16), so the tail is always sufficient. Files smaller than 2 MB take the original full-read path.

## Test plan
- [ ] `pytest tests/test_aggregate_wf_results.py` — 75 passed (5 new in `TestLargeFileSupport`)
- [ ] New tests monkeypatch `_TAIL_BYTES` to 8192 so a synthetic ~20 KB UTF-16 LE file exercises the tail-seek branch without allocating GB in CI
- [ ] Manual smoke: feed `logs/phase8_gamma_g2/G2_slippage_1M.log` (1.3 GB UTF-16 LE) directly to `aggregate_wf_results.py` and compare output against the existing `result.log` 30 KB workaround file

🤖 Generated with [Claude Code](https://claude.com/claude-code)