### PR TITLE
docs(phase8): G2 gate dry-run result + schema verification

### DIFF
--- a/docs/phase8/README.md
+++ b/docs/phase8/README.md
@@ -2,7 +2,8 @@
 
 **Plan**: `/Users/skylar/.claude/plans/phase8-restructured.md`
 **Supersedes**: `/Users/skylar/.claude/plans/phase8-early-items.md`
-**Started**: 2026-04-27
+**Started**: 2026-04-27  
+**Gate dry-run**: [`docs/phase8/g2_gate_dryrun_result.md`](g2_gate_dryrun_result.md) — G2 gate: 3 FAIL / 4 PASS, exit 2 (expected), no schema errors (2026-05-17)
 
 ---
 

--- a/docs/phase8/g2_gate_dryrun_result.md
+++ b/docs/phase8/g2_gate_dryrun_result.md
@@ -1,0 +1,118 @@
+# G2 Live Signal Gate — Dry-Run Result
+
+**Date**: 2026-05-17  
+**Evidence pack**: `docs/phase8/strategy_evidence_v1.md`  
+**Gate code**: `deployment/governance/live_signal_gate.py`  
+**Config**: `config/deployment.yaml` (`live_signal_gate` section)
+
+---
+
+## Command
+
+```
+python -m deployment.governance.live_signal_gate \
+  --evidence-pack docs/phase8/strategy_evidence_v1.md \
+  --config config/deployment.yaml
+```
+
+## Output
+
+```
+❌ Signal gate FAILED — live mode NOT authorized
+   • bootstrap_ci_lower -0.0061 ≤ threshold 0.0
+   • permutation_p 0.0999 ≥ threshold 0.05
+   • max_regime_dd.bear 0.3380 ≥ threshold 0.3
+```
+
+**Exit code: 2** (gate failed — expected)
+
+---
+
+## Per-Check Results
+
+| Check | Field | Value | Threshold | Result |
+|-------|-------|-------|-----------|--------|
+| Net Sharpe | `metrics.net_sharpe` | 1.4205 | > 0.5 | ✅ PASS |
+| DSR | `metrics.dsr` | 1.3077 | > 0.0 | ✅ PASS |
+| Bootstrap CI lower | `metrics.bootstrap_ci_lower` | −0.0061 | > 0.0 | ❌ FAIL |
+| Permutation p-value | `metrics.permutation_p` | 0.0999 | < 0.05 | ❌ FAIL |
+| Max regime DD — bear | `metrics.max_regime_dd.bear` | 0.3380 | < 0.30 | ❌ FAIL |
+| Max regime DD — bull | `metrics.max_regime_dd.bull` | 0.1698 | < 0.30 | ✅ PASS |
+| Evidence pack age | `generated_at` | 0.0 days | < 30 days | ✅ PASS |
+
+**Summary**: 3 failures, 4 passes. Exit code 2 (gate failed).
+
+---
+
+## Schema Verification
+
+No schema errors. The frontmatter parsed cleanly:
+
+- `max_regime_dd` is a YAML mapping (`bear: 0.3380`, `bull: 0.1698`) — gate code handles this
+  correctly via `isinstance(regime_dd, dict)` check (line 166) and per-regime iteration.
+- `bootstrap_ci_lower`, `net_sharpe`, `dsr`, `permutation_p` are all scalar floats — parsed
+  correctly via `_get_float()`.
+- `generated_at: "2026-05-17T00:00:00+00:00"` is ISO-8601 with timezone — age computed as
+  0.0 days (evidence is fresh).
+
+No schema fixes were required.
+
+---
+
+## Expected Failures
+
+### 1. `bootstrap_ci_lower` − FAIL (expected)
+
+**Value**: −0.0061 (CI lower bound = −0.61%)  
+**Threshold**: > 0.0  
+**Justification**: Block bootstrap CI straddles zero: [−0.61%, +4.70%]. Mean return is +2.05%
+but the confidence interval includes negative territory. This is a genuine statistical
+uncertainty, not a data quality issue. n=12 folds is borderline; the Phase 8 Statistical Power
+Extension plan (2026-05-17) recommends n≥21 (A3: 3-year data) to push the CI fully above zero
+at p<0.05. This failure is intentional — the gate is correctly blocking live trading until
+statistical evidence is tighter.
+
+### 2. `permutation_p` − FAIL (expected)
+
+**Value**: 0.0999 (p ≈ 0.10)  
+**Threshold**: < 0.05  
+**Justification**: 10% chance the observed +2.05% mean return is due to random label permutation.
+This is 2× the gate threshold of 0.05. With n=12 folds, power is limited. The same A3 data
+extension (n=24 folds) is expected to bring permutation p below 0.05 (projected t=2.01, p≈0.03).
+This failure is intentional.
+
+### 3. `max_regime_dd.bear` − FAIL (expected)
+
+**Value**: 0.3380 (mean bear-regime MaxDD = 33.8%)  
+**Threshold**: < 0.30 (30%)  
+**Justification**: The 3.8pp overage is driven by 3 crisis folds with extreme fixed-start MaxDD
+(fold 0: 90.4%, fold 2: 88.1%, fold 5: 58.1%). These are fixed-start eval artifacts: long fixed
+episodes allow full capital drawdown in adverse bear sub-periods. Four of 7 bear folds have 0%
+fixed-start MaxDD. The marginal nature of this failure (33.8% vs 30% threshold) makes it a
+candidate for operator threshold review rather than a re-train trigger. This failure is flagged as
+intentional but warrants separate operator assessment.
+
+---
+
+## Unexpected Issues
+
+None. Gate code and evidence pack schema are fully aligned. No code bugs were found during
+this dry-run.
+
+---
+
+## Operator Decision Required
+
+The 3 failures map to two root causes:
+
+1. **Statistical power** (`bootstrap_ci_lower`, `permutation_p`): Resolved by A3 (3-year data
+   expansion to n≥21 folds). Estimated effort: 30 min data prep + 1M-step re-train × 9 new folds.
+   See `/Users/skylar/.claude/plans/phase8-statistical-power-extension.md`.
+
+2. **Bear MaxDD margin** (`max_regime_dd.bear`): Operator may lower threshold to 0.35 (aligning
+   with observed mean) or accept the current evidence as sufficient for paper-trading entry while
+   re-training. The 4/7 bear-fold zero-MaxDD result suggests the crisis folds are outliers, not
+   the norm.
+
+**Recommended path**: Proceed to paper trading (not live) under current evidence while A3 runs.
+Gate correctly blocks live; paper trading does not require gate passage.


### PR DESCRIPTION
## Summary

- Ran `live_signal_gate` CLI against G2 evidence pack (`docs/phase8/strategy_evidence_v1.md`) with production config (`config/deployment.yaml`)
- Schema parsed cleanly — no frontmatter errors, `max_regime_dd` dict handled correctly
- Exit code 2 with **3 expected failures**, **4 passes** — gate correctly blocks live trading
- Added `docs/phase8/g2_gate_dryrun_result.md` with per-check table, schema verification, and failure justifications
- Added one-line reference to `docs/phase8/README.md`

## Gate result

| Check | Value | Threshold | Result |
|-------|-------|-----------|--------|
| net_sharpe | 1.4205 | > 0.5 | ✅ PASS |
| dsr | 1.3077 | > 0.0 | ✅ PASS |
| bootstrap_ci_lower | −0.0061 | > 0.0 | ❌ FAIL (expected) |
| permutation_p | 0.0999 | < 0.05 | ❌ FAIL (expected) |
| max_regime_dd.bear | 0.3380 | < 0.30 | ❌ FAIL (expected) |
| max_regime_dd.bull | 0.1698 | < 0.30 | ✅ PASS |
| evidence_pack_age | 0.0 days | < 30 days | ✅ PASS |

## Expected failures (justified)

- **bootstrap_ci_lower**: CI = [−0.61%, +4.70%] straddles zero; n=12 folds insufficient — resolves with A3 data expansion (n≥21)
- **permutation_p**: p=0.10 is 2× the 0.05 gate threshold; limited by n=12 — resolves with A3
- **max_regime_dd.bear**: 33.8% vs 30% threshold; driven by 3 crisis folds with fixed-start artifacts; 4/7 bear folds have 0% MaxDD — operator threshold review candidate

## No schema issues

Gate code and evidence pack schema are fully aligned. No numbers were changed. No gate code bugs found.

## Test plan
- [x] Gate CLI exits with code 2 (gate failed — expected)
- [x] All 3 expected failures appear in output
- [x] No unexpected failures or schema parse errors
- [x] Pre-existing test failure (`test_config_file_count_reduced`) is unrelated to this PR (YAML file count, not doc changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)